### PR TITLE
fix: cerrar huecos pendientes para que la migración Firebase funcione…

### DIFF
--- a/.github/workflows/og-publish.yml
+++ b/.github/workflows/og-publish.yml
@@ -29,6 +29,10 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      # Flag a nivel de job: 'true' si el secret existe, 'false' si no.
+      # Se evalúa aquí (no dentro de cada step) para que el if: pueda leerlo.
+      HAS_FIREBASE_CREDS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON != '' }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -43,7 +47,7 @@ jobs:
 
       # ── Paso 1: Generar /p/*.html desde Firestore (si hay credenciales) ────
       - name: Generar páginas SEO desde Firestore
-        if: ${{ env.GOOGLE_APPLICATION_CREDENTIALS_JSON != '' }}
+        if: ${{ env.HAS_FIREBASE_CREDS == 'true' }}
         env:
           GOOGLE_APPLICATION_CREDENTIALS_JSON: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON }}
           BASE_URL: ${{ inputs.base_url || 'https://altorrainmobiliaria.co' }}
@@ -56,10 +60,9 @@ jobs:
 
       # ── Paso 2 (fallback): Generar /p/*.html desde data.json (sin credenciales) ──
       - name: Generar páginas OG desde data.json (fallback)
-        if: ${{ env.GOOGLE_APPLICATION_CREDENTIALS_JSON == '' }}
+        if: ${{ env.HAS_FIREBASE_CREDS != 'true' }}
         env:
           OG_BASE_URL: ${{ inputs.base_url || 'https://altorrainmobiliaria.co' }}
-          GOOGLE_APPLICATION_CREDENTIALS_JSON: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON }}
         run: node tools/generate_og_pages.js
 
       # ── Paso 3: Bump deploy-info.json ──────────────────────────────────────

--- a/AVANCES.md
+++ b/AVANCES.md
@@ -2,7 +2,7 @@
 ## Bitácora de implementación hacia plataforma dinámica con Firebase
 
 > Documento vivo. Se actualiza con cada microfase completada.
-> Última actualización: 2026-04-10
+> Última actualización: 2026-04-10 (sesión de auditoría y fixes)
 
 ---
 
@@ -47,20 +47,100 @@ FASE PREVIA — Dominio y correo:            ✅ Completado
 FASE DOC    — CLAUDE.md + ALTORRACARSCLAUDE.md: ✅ Completado
 Etapa 0-A   — Archivos base Firebase:      ✅ Completado
 Etapa 0-B   — Proyecto Firebase + servicios: ✅ Completado (2026-04-10)
-Etapa 0-C   — Cloud Functions deploy:      ⚠️  Parcial (createManagedUserV2 OK, resto falla por permisos Eventarc)
-Etapa 1     — Lectura dinámica Firestore:  ✅ Completado (credenciales reales en firebase-config.js)
-Etapa 2     — Formularios → Firestore:     ⚠️  Parcial (código listo, Functions pendientes de fix)
-Etapa 3     — Panel de administración:     ✅ Completado (activa con credenciales)
-Etapa 4     — Imágenes en Cloud Storage:   ✅ Script listo (ejecutar cuando Firebase esté activo)
-Etapa 5     — SEO dinámico + CI/CD:        ✅ Script + workflow listos (ejecutar con credenciales)
+Etapa 0-C   — Cloud Functions deploy:      ⚠️  Parcial (createManagedUserV2 OK, resto requiere re-deploy: ver DEPLOY-RUNBOOK.md)
+Etapa 1     — Lectura dinámica Firestore:  ✅ Código listo — falta poblar Firestore (npm run upload)
+Etapa 2     — Formularios → Firestore:     ⚠️  Código listo — falta re-deploy de Functions
+Etapa 3     — Panel de administración:     ✅ Código listo — updateUserRoleV2 añadida en esta sesión
+Etapa 4     — Imágenes en Cloud Storage:   ✅ Script listo (bucket name corregido, ejecutar npm run migrate-images)
+Etapa 5     — SEO dinámico + CI/CD:        ✅ Script + workflow listos (bug del if: arreglado, falta secret GOOGLE_APPLICATION_CREDENTIALS_JSON)
 Etapa 6     — Favoritos sincronizados:     ✅ Completado (funciona local + sync Firebase automático)
 Etapa 7     — Analytics y Marketing:       ✅ Completado (GA4 activa con measurementId)
-Etapa 8     — Mejoras comerciales:         ✅ Completado (código listo, Google Maps key y VAPID pendientes)
+Etapa 8     — Mejoras comerciales:         ✅ Código listo — claves centralizadas en window.AltorraKeys (ver DEPLOY-RUNBOOK.md)
 ```
+
+**📖 Runbook del propietario:** `DEPLOY-RUNBOOK.md` contiene los 6 pasos
+pendientes con comandos PowerShell exactos. Cuando todos estén ejecutados,
+la migración estará 100% completa.
 
 ---
 
 ## REGISTRO DE FASES COMPLETADAS
+
+---
+
+### ✅ SESIÓN AUDITORÍA Y FIXES (2026-04-10)
+
+**Contexto:** Al revisar los MDs y auditar el estado real del código, se encontraron
+6 bugs/huecos que impedían que "todo lo marcado como listo" funcionara de verdad
+en cuanto el propietario ejecute los pasos pendientes. Todos arreglados en esta sesión.
+
+**Bugs arreglados:**
+
+1. **Bucket name incorrecto en `scripts/migrate-images-to-storage.mjs`** — estaba
+   hardcodeado `altorra-inmobiliaria.appspot.com` pero el proyecto real es
+   `altorra-inmobiliaria-345c6.firebasestorage.app`. Ahora es configurable con
+   variable de entorno `STORAGE_BUCKET` y el default apunta al bucket correcto.
+
+2. **Placeholder de Google Maps API key expuesto en `js/mapa-propiedades.js`** —
+   había una key de aspecto real pero ficticia. Ahora la key se lee desde
+   `window.AltorraKeys.gmapsApiKey` (centralizada en `firebase-config.js`).
+   Si falta, el mapa muestra un mensaje claro "Mapa no disponible" en vez de romperse.
+
+3. **Placeholder VAPID key en `js/push-notifications.js`** — mismo patrón. Ahora
+   se lee desde `window.AltorraKeys.vapidKey`. Si no está configurada, el botón
+   de suscripción se oculta automáticamente y `requestPermission()` retorna null
+   sin errores.
+
+4. **Función `updateUserRoleV2` faltante en `functions/index.js`** — `admin-users.js`
+   la llamaba con `httpsCallable` pero no estaba definida en el backend, lo que
+   habría roto el cambio de rol desde el panel admin. Añadida con la misma
+   validación de `requireSuperAdmin` + guard anti-auto-degradación.
+
+5. **Bug en `.github/workflows/og-publish.yml`** — la condición
+   `if: ${{ env.GOOGLE_APPLICATION_CREDENTIALS_JSON != '' }}` intentaba leer una
+   variable de entorno que solo existe dentro del propio step, por lo que siempre
+   evaluaba a truthy aunque el secret no existiera. Ahora se usa un env a nivel
+   de job (`HAS_FIREBASE_CREDS`) para elegir entre Firestore y el fallback a
+   `data.json` correctamente.
+
+6. **Script `migrate-images` no expuesto en `package.json`** — añadido como
+   `npm run migrate-images`.
+
+**Otras mejoras:**
+
+- Se creó `DEPLOY-RUNBOOK.md` en la raíz: documento ejecutable con los pasos
+  exactos (comandos PowerShell) que el propietario debe correr para terminar
+  los 6 bloqueantes pendientes. Incluye: fix Eventarc, subir propiedades,
+  migrar imágenes, configurar secret de GitHub Actions, Google Maps key y
+  VAPID key. También tiene checklist de verificación final y troubleshooting.
+
+- Comentario de cabecera de `js/firebase-config.js` simplificado: ya no dice
+  "TODO reemplazar credenciales" porque las credenciales ya están puestas.
+  Explica el rol de `window.AltorraKeys` como único bloque que el propietario
+  necesita editar para las claves opcionales.
+
+**Archivos modificados en esta sesión:**
+```
+js/firebase-config.js              (+window.AltorraKeys, docs actualizada)
+js/mapa-propiedades.js             (lee gmapsApiKey desde AltorraKeys + fallback limpio)
+js/push-notifications.js           (lee vapidKey desde AltorraKeys + no-op si falta)
+functions/index.js                 (+updateUserRoleV2, actualiza header de docs)
+scripts/migrate-images-to-storage.mjs (bucket correcto + env STORAGE_BUCKET)
+.github/workflows/og-publish.yml   (HAS_FIREBASE_CREDS a nivel de job)
+package.json                       (+script migrate-images)
+DEPLOY-RUNBOOK.md                  (NUEVO — runbook para el propietario)
+AVANCES.md                         (esta sección)
+```
+
+**Lo que sigue bloqueado hasta que el propietario ejecute el runbook:**
+- Fix de permisos Eventarc para completar deploy de las 6 Cloud Functions restantes
+- Ejecutar `npm run upload` para poblar Firestore
+- Ejecutar `npm run migrate-images` para subir fotos a Storage
+- Configurar secret `GOOGLE_APPLICATION_CREDENTIALS_JSON` en GitHub
+- Pegar Google Maps API key en `window.AltorraKeys.gmapsApiKey`
+- Pegar VAPID key en `window.AltorraKeys.vapidKey`
+
+Ver `DEPLOY-RUNBOOK.md` para los comandos exactos.
 
 ---
 

--- a/DEPLOY-RUNBOOK.md
+++ b/DEPLOY-RUNBOOK.md
@@ -1,0 +1,282 @@
+# DEPLOY-RUNBOOK.md — Altorra Inmobiliaria
+## Pasos pendientes que solo puede hacer el propietario
+
+> Fecha: 2026-04-10
+> Todas las tareas a continuación requieren credenciales, consola de Google Cloud
+> o acceso a la máquina local con Firebase CLI. Claude ya dejó el código listo.
+>
+> Project ID: `altorra-inmobiliaria-345c6`
+> Cuenta Firebase CLI: `altorrainmobiliaria@gmail.com`
+> Ruta local: `C:\Users\romad\Documents\GitHub\altorrainmobiliaria.github.io`
+
+---
+
+## ⚠️ BLOQUEANTE 1 — Completar deploy de Cloud Functions
+
+Solo `createManagedUserV2` se desplegó en el intento anterior. Las otras 6 funciones
+fallaron por el error "Eventarc Service Agent permission denied". Este es un error
+común en el primer deploy de Functions 2nd gen.
+
+### Opción A — Reintentar (lo más probable que funcione)
+
+El error de Eventarc suele resolverse solo tras unos minutos. Espera 10 min
+desde el último intento y ejecuta:
+
+```powershell
+cd C:\Users\romad\Documents\GitHub\altorrainmobiliaria.github.io\functions
+npm install
+cd ..
+firebase deploy --only functions --account altorrainmobiliaria@gmail.com
+```
+
+### Opción B — Dar permisos manualmente
+
+Si la Opción A falla:
+
+1. Abre IAM:
+   https://console.cloud.google.com/iam-admin/iam?project=altorra-inmobiliaria-345c6
+
+2. Click "Grant access" y añade los siguientes roles a estas cuentas de servicio:
+
+   | Cuenta de servicio | Rol a otorgar |
+   |---|---|
+   | `service-794130975989@gcp-sa-eventarc.iam.gserviceaccount.com` | `Eventarc Service Agent` |
+   | `794130975989@cloudbuild.gserviceaccount.com` | `Cloud Build Service Account` |
+   | `794130975989-compute@developer.gserviceaccount.com` | `Cloud Run Invoker` |
+
+3. Verifica que estas APIs estén habilitadas:
+   - https://console.cloud.google.com/apis/library/cloudbuild.googleapis.com?project=altorra-inmobiliaria-345c6
+   - https://console.cloud.google.com/apis/library/eventarc.googleapis.com?project=altorra-inmobiliaria-345c6
+   - https://console.cloud.google.com/apis/library/run.googleapis.com?project=altorra-inmobiliaria-345c6
+   - https://console.cloud.google.com/apis/library/pubsub.googleapis.com?project=altorra-inmobiliaria-345c6
+
+4. Espera 2-3 minutos y reintenta el deploy:
+   ```powershell
+   firebase deploy --only functions --account altorrainmobiliaria@gmail.com
+   ```
+
+### Qué funciones debe quedar desplegadas al terminar
+
+| Función | Tipo | Lo que hace |
+|---|---|---|
+| `onNewSolicitud` | Firestore trigger | Email al admin cuando llega un lead |
+| `onSolicitudStatusChanged` | Firestore trigger | Email al cliente cuando cambia estado |
+| `onPropertyChange` | Firestore trigger | Regenera SEO (debounce 5 min) |
+| `triggerSeoRegeneration` | HTTPS callable | Forzar regeneración SEO desde admin |
+| `createManagedUserV2` | HTTPS callable | ✅ (ya desplegada) |
+| `deleteManagedUserV2` | HTTPS callable | Eliminar usuario admin |
+| `updateUserRoleV2` | HTTPS callable | **NUEVO** — cambiar rol de usuario |
+
+Verificación post-deploy:
+```powershell
+firebase functions:list --account altorrainmobiliaria@gmail.com
+```
+Debe mostrar las 7 funciones.
+
+---
+
+## BLOQUEANTE 2 — Subir las 5 propiedades a Firestore
+
+Sin esto, el sitio muestra el fallback a `properties/data.json` (que funciona,
+pero no usa Firestore).
+
+### Pasos
+
+1. Descargar service account:
+   - https://console.firebase.google.com/project/altorra-inmobiliaria-345c6/settings/serviceaccounts/adminsdk
+   - Click "Generate new private key"
+   - Guardar como `C:\Users\romad\sa-altorra-inmobiliaria.json`
+   - **NO commitear este archivo al repo**.
+
+2. Ejecutar desde la raíz del repo:
+   ```powershell
+   cd C:\Users\romad\Documents\GitHub\altorrainmobiliaria.github.io
+   npm install
+   $env:GOOGLE_APPLICATION_CREDENTIALS = "C:\Users\romad\sa-altorra-inmobiliaria.json"
+   npm run upload
+   ```
+
+3. Verifica en la consola:
+   https://console.firebase.google.com/project/altorra-inmobiliaria-345c6/firestore/data/~2Fpropiedades
+
+   Debe haber 5 documentos: `101-27`, `102-11402`, `103-B305`, `104-01`, `105-4422`.
+
+---
+
+## BLOQUEANTE 3 — Subir imágenes a Cloud Storage
+
+### Pasos
+
+1. Primero dry-run para ver qué haría:
+   ```powershell
+   $env:GOOGLE_APPLICATION_CREDENTIALS = "C:\Users\romad\sa-altorra-inmobiliaria.json"
+   $env:DRY_RUN = "1"
+   npm run migrate-images
+   ```
+
+2. Si el dry-run se ve bien, ejecuta de verdad:
+   ```powershell
+   Remove-Item Env:\DRY_RUN
+   npm run migrate-images
+   ```
+
+   Esto sube 5 carpetas (`allure/`, `fmia/`, `serena/`, `fotoprop/`, `Milan/`)
+   a `gs://altorra-inmobiliaria-345c6.firebasestorage.app/propiedades/{id}/*`
+   y actualiza las URLs en los documentos Firestore.
+
+3. Verifica en el navegador que una de las URLs cargue, ej.:
+   ```
+   https://storage.googleapis.com/altorra-inmobiliaria-345c6.firebasestorage.app/propiedades/101-27/allure.webp
+   ```
+
+4. Solo cuando veas que las imágenes cargan desde Storage, puedes eliminar
+   las carpetas locales:
+   ```powershell
+   git rm -r allure/ fmia/ serena/ fotoprop/ Milan/
+   git commit -m "chore: eliminar imagenes locales migradas a Cloud Storage"
+   ```
+
+---
+
+## BLOQUEANTE 4 — Secret `GOOGLE_APPLICATION_CREDENTIALS_JSON` en GitHub Actions
+
+Sin esto, el workflow `og-publish.yml` cae al fallback que genera `/p/*.html`
+desde `data.json` en vez de Firestore.
+
+### Pasos
+
+1. Abrir el mismo service account JSON que descargaste arriba.
+
+2. Copiar su contenido completo (es un JSON de ~2-3 KB).
+
+3. Ir a:
+   https://github.com/altorrainmobiliaria/altorrainmobiliaria.github.io/settings/secrets/actions
+
+4. Click "New repository secret":
+   - Name: `GOOGLE_APPLICATION_CREDENTIALS_JSON`
+   - Secret: pegar el contenido del JSON tal cual
+
+5. Verificar disparando el workflow manualmente:
+   https://github.com/altorrainmobiliaria/altorrainmobiliaria.github.io/actions/workflows/og-publish.yml
+   → click "Run workflow"
+
+   En los logs deberías ver: "Generar páginas SEO desde Firestore" ejecutándose
+   (no el paso de fallback).
+
+---
+
+## OPCIONAL 5 — Google Maps API key
+
+Sin esto, la página `/mapa.html` muestra "Mapa no disponible: falta configurar
+la clave de Google Maps". El resto del sitio funciona normal.
+
+### Pasos
+
+1. Ir a https://console.cloud.google.com/google/maps-apis/credentials?project=altorra-inmobiliaria-345c6
+
+2. Click "Create credentials" → "API key".
+
+3. Restringir la clave:
+   - **Application restrictions:** HTTP referrers
+     - `https://altorrainmobiliaria.co/*`
+     - `https://*.altorrainmobiliaria.co/*`
+     - `http://localhost/*` (para desarrollo)
+   - **API restrictions:** Maps JavaScript API
+
+4. Copiar la key.
+
+5. Editar `js/firebase-config.js`, buscar el bloque `window.AltorraKeys`:
+
+   ```javascript
+   window.AltorraKeys = Object.assign({
+     gmapsApiKey: '',   // ← pegar la key aquí
+     vapidKey:    '',
+   }, window.AltorraKeys || {});
+   ```
+
+6. Commit y push:
+   ```powershell
+   git add js/firebase-config.js
+   git commit -m "chore: agregar Google Maps API key"
+   git push
+   ```
+
+---
+
+## OPCIONAL 6 — VAPID key para notificaciones push (FCM)
+
+Sin esto, el botón de "Activar alertas" se oculta automáticamente y no hay push.
+
+### Pasos
+
+1. Ir a: https://console.firebase.google.com/project/altorra-inmobiliaria-345c6/settings/cloudmessaging
+
+2. En "Web configuration" → "Web Push certificates" → click "Generate key pair".
+
+3. Copiar la key (es un string largo tipo `BNxD...`).
+
+4. Editar `js/firebase-config.js`, mismo bloque:
+   ```javascript
+   window.AltorraKeys = Object.assign({
+     gmapsApiKey: '...',     // ya está
+     vapidKey:    'BNxD...', // ← pegar aquí
+   }, window.AltorraKeys || {});
+   ```
+
+5. Commit y push.
+
+---
+
+## CHECKLIST DE VERIFICACIÓN FINAL
+
+Una vez hechos los bloqueantes 1-4:
+
+- [ ] `firebase functions:list` muestra 7 funciones
+- [ ] Firestore Console muestra 5 documentos en `propiedades/`
+- [ ] Firestore Console muestra `system/meta`, `config/general`, `config/counters`
+- [ ] Storage Console muestra carpetas en `propiedades/{id}/`
+- [ ] Abrir https://altorrainmobiliaria.co/ — debe cargar y mostrar las 5 propiedades
+- [ ] Abrir `admin.html` y hacer login con `info@altorrainmobiliaria.co`
+- [ ] Crear un lead de prueba desde `contacto.html` → verificar que:
+  - Aparece en Firestore `solicitudes/`
+  - Llega email a `info@altorrainmobiliaria.co` (función `onNewSolicitud`)
+- [ ] Desde el admin, editar una propiedad → verificar que:
+  - Se actualiza `updatedAt` en Firestore
+  - El workflow `og-publish.yml` se dispara tras 5 min (`onPropertyChange`)
+  - La página `/p/{id}.html` refleja los cambios nuevos
+- [ ] Abrir `/mapa.html` — muestra el mapa (o el mensaje si falta la Maps key)
+
+---
+
+## TROUBLESHOOTING
+
+### "Firestore Database does not exist in region nam5"
+Probable que aún no esté activado. Ve a:
+https://console.firebase.google.com/project/altorra-inmobiliaria-345c6/firestore
+y click "Create database".
+
+### "Missing or insufficient permissions" en admin panel
+El usuario logueado no tiene documento en `/usuarios/{uid}` o `rol !== 'super_admin'`.
+Verifica en Firestore que exista `usuarios/J1sXuV78OhPA5KyCoWNYFVQehF23` con
+`{ rol: "super_admin", activo: true, bloqueado: false }`.
+
+### Las páginas del admin se ven en blanco
+Abre DevTools y mira la consola. Lo más común:
+- `window.functions` no definido → el SDK diferido de Firebase no terminó de cargar.
+  Refrescar debería resolverlo.
+- `onSnapshot` permisos → el usuario logueado no es editor/super_admin.
+
+### El workflow corre pero no genera páginas nuevas
+Verifica que el secret `GOOGLE_APPLICATION_CREDENTIALS_JSON` existe y que el
+JSON es válido. En los logs del workflow debe decir "Generar páginas SEO desde
+Firestore" (no "fallback").
+
+### Las funciones no responden
+```powershell
+firebase functions:log --account altorrainmobiliaria@gmail.com
+```
+Revisa errores de secrets o de permisos de Firestore.
+
+---
+
+*Fin del runbook — cuando todos los checkboxes estén verdes, la migración está completa.*

--- a/functions/index.js
+++ b/functions/index.js
@@ -15,6 +15,8 @@
  *                              Crea usuario Firebase Auth + documento en /usuarios
  *   deleteManagedUserV2      → HTTPS callable (solo super_admin)
  *                              Elimina usuario Firebase Auth + documento en /usuarios
+ *   updateUserRoleV2         → HTTPS callable (solo super_admin)
+ *                              Actualiza el rol de un usuario en /usuarios/{uid}
  *
  * SECRETS (configurar con: firebase functions:secrets:set SECRET_NAME):
  *   EMAIL_USER   → cuenta Gmail remitente (ej. notificaciones@altorrainmobiliaria.co)
@@ -342,6 +344,41 @@ exports.deleteManagedUserV2 = onCall(
     }
 
     await db.collection('usuarios').doc(uid).delete();
+    return { success: true };
+  }
+);
+
+// ══════════════════════════════════════════════════════════════════════════
+// 7. updateUserRoleV2 — Cambiar el rol de un usuario admin
+// ══════════════════════════════════════════════════════════════════════════
+exports.updateUserRoleV2 = onCall(
+  { region: REGION },
+  async (request) => {
+    await requireSuperAdmin(request.auth?.uid);
+
+    const { uid, rol } = request.data || {};
+    if (!uid || !rol) {
+      throw new HttpsError('invalid-argument', 'Se requieren uid y rol.');
+    }
+    if (!['super_admin', 'editor', 'viewer'].includes(rol)) {
+      throw new HttpsError('invalid-argument', 'Rol inválido.');
+    }
+    if (uid === request.auth.uid && rol !== 'super_admin') {
+      throw new HttpsError('failed-precondition', 'No puedes quitarte tu propio rol de super_admin.');
+    }
+
+    const ref = db.collection('usuarios').doc(uid);
+    const snap = await ref.get();
+    if (!snap.exists) {
+      throw new HttpsError('not-found', 'Usuario no existe en /usuarios.');
+    }
+
+    await ref.update({
+      rol,
+      actualizadoEn:  FieldValue.serverTimestamp(),
+      actualizadoPor: request.auth.uid,
+    });
+
     return { success: true };
   }
 );

--- a/js/firebase-config.js
+++ b/js/firebase-config.js
@@ -2,17 +2,33 @@
  * firebase-config.js — Altorra Inmobiliaria
  * Inicialización de Firebase con carga prioritaria.
  *
- * CREDENCIALES: Reemplazar los valores TODO con los del proyecto Firebase.
  * Las API keys de Firebase son públicas por diseño (la seguridad real
- * está en firestore.rules y storage.rules).
+ * está en firestore.rules, storage.rules y database.rules.json).
+ *
+ * El propietario solo necesita mantener actualizados:
+ *   - FIREBASE_CONFIG      (ya con valores reales del proyecto)
+ *   - window.AltorraKeys   (Google Maps + VAPID / FCM — ver arriba)
  *
  * Patrón: carga crítica primero (Auth + Firestore), resto diferido.
  */
 
+// ══════════════════════════════════════════════════════════════════════════
+// Claves adicionales del proyecto (Google Maps, FCM, etc.)
+// El propietario SOLO debe editar este bloque — los módulos consumidores
+// (mapa-propiedades.js, push-notifications.js) leen desde window.AltorraKeys.
+// ══════════════════════════════════════════════════════════════════════════
+window.AltorraKeys = Object.assign({
+  // Google Maps JavaScript API — https://console.cloud.google.com/google/maps-apis
+  // Restringir por HTTP referrer a altorrainmobiliaria.co y *.altorrainmobiliaria.co
+  gmapsApiKey: '',
+  // FCM Web Push — Firebase Console → Project settings → Cloud Messaging → Web Push certificates
+  vapidKey:    '',
+}, window.AltorraKeys || {});
+
 (async function initFirebase() {
   // ── Configuración del proyecto ─────────────────────────────────
-  // TODO: reemplazar con los valores reales de Firebase Console
-  // Proyecto → Configuración del proyecto → Tus apps → Config
+  // Las API keys de Firebase son públicas por diseño — la seguridad
+  // real vive en firestore.rules / storage.rules / database.rules.json.
   const FIREBASE_CONFIG = {
     apiKey:            'AIzaSyCLxOwj3837m6p9QFDBWzVTuNUFhBkCg_I',
     authDomain:        'altorra-inmobiliaria-345c6.firebaseapp.com',

--- a/js/mapa-propiedades.js
+++ b/js/mapa-propiedades.js
@@ -6,7 +6,11 @@
      API pública: window.MapaPropiedades.{init, setFilter, destroy}
   ────────────────────────────────────────────────────────────────*/
 
-  const GMAPS_API_KEY = 'AIzaSyBnWoMzVZCqJNUdFzHx4e0Yfn7Pv2R3tXs'; // reemplazar con key real
+  // La API key se lee desde window.AltorraKeys.gmapsApiKey (definida en firebase-config.js).
+  // Si está vacía, el mapa muestra un estado "no configurado" en lugar de romperse.
+  function getGmapsKey() {
+    return (window.AltorraKeys && window.AltorraKeys.gmapsApiKey) || '';
+  }
   const DEFAULT_CENTER = { lat: 10.391049, lng: -75.479426 }; // Cartagena
   const DEFAULT_ZOOM   = 12;
 
@@ -21,12 +25,15 @@
   /* ── Carga dinámica de Google Maps SDK ── */
   function loadGoogleMaps() {
     if (_gmLoaded || window.google?.maps) { _gmLoaded = true; return Promise.resolve(); }
-    if (_gmLoaded) return Promise.resolve();
+    const key = getGmapsKey();
+    if (!key) {
+      return Promise.reject(new Error('GMAPS_API_KEY_MISSING'));
+    }
     return new Promise((resolve, reject) => {
       const callbackName = '__altorra_maps_cb';
       window[callbackName] = () => { _gmLoaded = true; resolve(); };
       const s = document.createElement('script');
-      s.src = `https://maps.googleapis.com/maps/api/js?key=${GMAPS_API_KEY}&callback=${callbackName}&loading=async`;
+      s.src = `https://maps.googleapis.com/maps/api/js?key=${encodeURIComponent(key)}&callback=${callbackName}&loading=async`;
       s.async = true;
       s.onerror = reject;
       document.head.appendChild(s);
@@ -312,10 +319,13 @@
 
     } catch (err) {
       console.error('[MapaPropiedades] Error:', err);
+      const msg = err && err.message === 'GMAPS_API_KEY_MISSING'
+        ? 'Mapa no disponible: falta configurar la clave de Google Maps.'
+        : 'No se pudo cargar el mapa. Verifica tu conexión o la clave de Google Maps.';
       wrapper.innerHTML = `
         <div style="height:100%;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:12px;color:#6b7280;font-size:.9rem;padding:24px;text-align:center">
           <span style="font-size:2rem">🗺️</span>
-          <span>No se pudo cargar el mapa. Configura tu clave de Google Maps API.</span>
+          <span>${msg}</span>
         </div>`;
     }
   }

--- a/js/push-notifications.js
+++ b/js/push-notifications.js
@@ -3,19 +3,22 @@
 
   /* ──────────────────────────────────────────────────────────────
      push-notifications.js  — Firebase Cloud Messaging (FCM)
-     Requiere: VAPID key en firebase-config.js + service worker registrado
+     Requiere: VAPID key en window.AltorraKeys.vapidKey (firebase-config.js)
+              + service worker registrado
 
      Para activar:
      1. Obtener VAPID public key desde Firebase Console
         (Project settings → Cloud Messaging → Web Push certificates)
-     2. Reemplazar VAPID_KEY abajo
-     3. Descomentar el registro del SW en service-worker.js
+     2. Pegarla en window.AltorraKeys.vapidKey (firebase-config.js)
+     3. Asegurar que el service worker esté registrado
      4. El usuario debe dar permiso al hacer clic en un CTA
 
      API pública: window.AltorraPush.{requestPermission, subscribe, unsubscribe, isSupported}
   ────────────────────────────────────────────────────────────────*/
 
-  const VAPID_KEY = 'REEMPLAZAR_CON_VAPID_KEY_DE_FIREBASE_CONSOLE';
+  function getVapidKey() {
+    return (window.AltorraKeys && window.AltorraKeys.vapidKey) || '';
+  }
   const LS_TOKEN  = 'altorra:fcm-token';
   const LS_SUBS   = 'altorra:push-subscribed';
 
@@ -39,6 +42,10 @@
       console.warn('[Push] No soportado en este navegador');
       return null;
     }
+    if (!getVapidKey()) {
+      console.warn('[Push] VAPID key no configurada en window.AltorraKeys.vapidKey');
+      return null;
+    }
 
     const perm = await Notification.requestPermission();
     if (perm !== 'granted') {
@@ -52,6 +59,8 @@
   async function subscribe() {
     const messaging = await getMessaging();
     if (!messaging) return null;
+    const vapidKey = getVapidKey();
+    if (!vapidKey) return null;
 
     try {
       const { getToken } =
@@ -59,7 +68,7 @@
 
       const sw = await navigator.serviceWorker.ready;
       const token = await getToken(messaging, {
-        vapidKey: VAPID_KEY,
+        vapidKey,
         serviceWorkerRegistration: sw,
       });
 
@@ -79,13 +88,15 @@
   async function unsubscribe() {
     const messaging = await getMessaging();
     if (!messaging) return;
+    const vapidKey = getVapidKey();
+    if (!vapidKey) return;
 
     try {
       const { getToken, deleteToken } =
         await import('https://www.gstatic.com/firebasejs/12.9.0/firebase-messaging.js');
 
       const sw    = await navigator.serviceWorker.ready;
-      const token = await getToken(messaging, { vapidKey: VAPID_KEY, serviceWorkerRegistration: sw });
+      const token = await getToken(messaging, { vapidKey, serviceWorkerRegistration: sw });
       if (token) await deleteToken(messaging, token);
 
       localStorage.removeItem(LS_TOKEN);
@@ -140,7 +151,7 @@
     const el = document.getElementById(containerId);
     if (!el) return;
 
-    if (!isSupported()) { el.style.display = 'none'; return; }
+    if (!isSupported() || !getVapidKey()) { el.style.display = 'none'; return; }
 
     const subscribed = localStorage.getItem(LS_SUBS) === '1';
     const label      = subscribed ? (opts.labelOff || 'Desactivar alertas') : (opts.labelOn || 'Activar alertas de propiedades');

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "generate": "node scripts/generate-properties.mjs",
-    "upload":   "node scripts/upload-to-firestore.mjs",
-    "backup":   "node scripts/backup-firestore.mjs"
+    "generate":       "node scripts/generate-properties.mjs",
+    "upload":         "node scripts/upload-to-firestore.mjs",
+    "migrate-images": "node scripts/migrate-images-to-storage.mjs",
+    "backup":         "node scripts/backup-firestore.mjs"
   },
   "dependencies": {
     "firebase": "^12.9.0"

--- a/scripts/migrate-images-to-storage.mjs
+++ b/scripts/migrate-images-to-storage.mjs
@@ -30,7 +30,8 @@ import { dirname } from 'path';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT      = join(__dirname, '..');
 const DRY_RUN   = process.env.DRY_RUN === '1';
-const BUCKET    = 'altorra-inmobiliaria.appspot.com';
+// Bucket real del proyecto (ver firebase-config.js). Override con STORAGE_BUCKET env.
+const BUCKET    = process.env.STORAGE_BUCKET || 'altorra-inmobiliaria-345c6.firebasestorage.app';
 
 // ── Mapa: carpeta local → propiedadId ──────────────────────────────────────
 const FOLDER_MAP = {


### PR DESCRIPTION
… end-to-end

Auditoría de estado encontró 6 bugs que impedían que el código marcado como "listo" funcionara cuando el propietario ejecute los pasos pendientes:

- scripts/migrate-images-to-storage.mjs: bucket hardcodeado al nombre legacy (.appspot.com) en vez del real (.firebasestorage.app); ahora configurable con env STORAGE_BUCKET y default correcto.
- js/mapa-propiedades.js + js/push-notifications.js: GMAPS_API_KEY y VAPID_KEY hardcodeadas con placeholders. Ahora se leen desde window.AltorraKeys (centralizado en firebase-config.js) y degradan limpiamente si faltan.
- functions/index.js: faltaba updateUserRoleV2 que admin-users.js ya invoca; añadida con requireSuperAdmin + guard anti-auto-degradación.
- .github/workflows/og-publish.yml: el if: leía env de step antes de que existiera (siempre truthy). Ahora usa HAS_FIREBASE_CREDS a nivel de job.
- package.json: añadido npm script migrate-images.
- js/firebase-config.js: limpiado comentario "TODO reemplazar" obsoleto.

Nuevo: DEPLOY-RUNBOOK.md con los 6 pasos pendientes del propietario (comandos PowerShell exactos para fix Eventarc, upload, migrate-images, secret de GitHub Actions, Maps key y VAPID key) + checklist y troubleshooting.

AVANCES.md actualizado con la sección de auditoría y fixes.