### PR TITLE
feat(realtime): sync admin→público en vivo + ocultar secciones vacías

### DIFF
--- a/js/cache-manager.js
+++ b/js/cache-manager.js
@@ -160,13 +160,16 @@
     await idbSet(key, value, ttlMs);
   }
 
-  /** Invalidar todas las capas y refrescar datos */
+  /** Invalidar todas las capas y refrescar datos.
+   *  Importante: espera a que PropertyDatabase termine de recargar ANTES de
+   *  disparar 'altorra:cache-invalidated', para que los listeners vean datos
+   *  frescos cuando consulten window.propertyDB.filter() / getById(). */
   async function invalidate() {
     memClear();
     lsClear();
     await idbClear();
     if (window.propertyDB && typeof window.propertyDB.refresh === 'function') {
-      window.propertyDB.refresh().catch(() => {});
+      try { await window.propertyDB.refresh(); } catch (_) { /* no crítico */ }
     }
     window.dispatchEvent(new CustomEvent('altorra:cache-invalidated'));
     console.log('[AltorraCache] Caché invalidada ✅');

--- a/js/database.js
+++ b/js/database.js
@@ -172,12 +172,62 @@
     return score;
   }
 
+  // ── Toast sutil de actualización en vivo (UX — patrón Altorra Cars) ──────
+  let _lastToastTs = 0;
+  function showUpdateToast() {
+    // Throttle: máximo un toast cada 3s
+    const now = Date.now();
+    if (now - _lastToastTs < 3000) return;
+    _lastToastTs = now;
+    try {
+      // No mostrar en admin ni si el documento no está visible
+      if (/\/admin\.html/i.test(location.pathname)) return;
+      if (document.hidden) return;
+
+      let toast = document.getElementById('altorra-rt-toast');
+      if (!toast) {
+        toast = document.createElement('div');
+        toast.id = 'altorra-rt-toast';
+        toast.style.cssText =
+          'position:fixed;bottom:24px;right:24px;background:#111;color:#fff;' +
+          'padding:10px 18px;border-radius:999px;font-weight:700;font-size:.88rem;' +
+          'box-shadow:0 10px 28px rgba(17,24,39,.18);opacity:0;' +
+          'transform:translateY(8px);transition:opacity .2s ease,transform .2s ease;' +
+          'z-index:9999;pointer-events:none;';
+        toast.textContent = '✓ Catálogo actualizado';
+        document.body.appendChild(toast);
+      }
+      requestAnimationFrame(() => {
+        toast.style.opacity = '1';
+        toast.style.transform = 'translateY(0)';
+      });
+      clearTimeout(toast._hideTimer);
+      toast._hideTimer = setTimeout(() => {
+        toast.style.opacity = '0';
+        toast.style.transform = 'translateY(8px)';
+      }, 2400);
+    } catch (_) {}
+  }
+
+  // ── Hash de contenido para detectar cambios reales ────────────────────────
+  // Incluye los campos que afectan la UI pública para evitar re-renders
+  // innecesarios cuando Firestore re-envía datos idénticos.
+  function contentHash(arr) {
+    return arr
+      .map(p => `${p.id}:${p._version || 0}:${p.available}:${p.featured || 0}:${p.price || 0}:${p.operation}:${p.estado}:${p.image}`)
+      .sort()
+      .join('|');
+  }
+
   // ── Clase principal ───────────────────────────────────────────────────────
   class PropertyDatabase {
     constructor() {
-      this._data       = [];     // todos los datos normalizados
-      this._loaded     = false;
-      this._listeners  = [];     // callbacks onChange
+      this._data            = [];     // todos los datos normalizados
+      this._loaded          = false;
+      this._listeners       = [];     // callbacks onChange
+      this._realtimeActive  = false;
+      this._unsubRealtime   = null;
+      this._rtDebounce      = null;
     }
 
     // Exponer los datos para consumidores que iteran sobre toda la lista
@@ -193,6 +243,8 @@
           this._loaded = true;
           this._ready();
           this._refreshInBackground();
+          // Arranca la suscripción en vivo en paralelo (no bloquea)
+          this.startRealtime();
           return this;
         }
       }
@@ -211,6 +263,8 @@
 
       this._loaded = true;
       this._ready();
+      // Arranca suscripción realtime tras la primera carga completa
+      this.startRealtime();
       return this;
     }
 
@@ -391,10 +445,85 @@
       return arr;
     }
 
-    /** Forzar recarga limpia (invalida cache) */
+    /** Forzar recarga limpia (invalida cache) y notificar a los consumidores
+     *  con 'altorra:db-refreshed' cuando los nuevos datos ya estén montados. */
     async refresh() {
       cacheClear();
-      return this.load(true);
+      await this.load(true);
+      this._notify();
+      window.dispatchEvent(new CustomEvent('altorra:db-refreshed'));
+      return this;
+    }
+
+    /** Suscripción en tiempo real a la colección propiedades (patrón Altorra Cars).
+     *
+     *  Emite 'altorra:db-refreshed' con 500ms de debounce cuando Firestore
+     *  notifica un cambio real (no al snapshot inicial, ni a datos idénticos).
+     *  De esta manera, cualquier create/edit/delete desde el admin aparece
+     *  en la web pública sin recargar la página.
+     *
+     *  Uso de lecturas: onSnapshot solo consume lecturas cuando hay cambios
+     *  reales; para un inventario de ≤100 propiedades esto es prácticamente
+     *  gratuito dentro del tier Blaze.
+     */
+    async startRealtime() {
+      if (this._realtimeActive) return;
+      this._realtimeActive = true;
+      try {
+        await waitForFirestore();
+        const { collection, onSnapshot, query, where, limit } =
+          await import('https://www.gstatic.com/firebasejs/12.9.0/firebase-firestore.js');
+
+        let firstSnapshot = true;
+        const self = this;
+
+        this._unsubRealtime = onSnapshot(
+          query(
+            collection(window.db, COLLECTION),
+            where('disponible', '==', true),
+            limit(100)
+          ),
+          (snapshot) => {
+            // El primer snapshot es la carga inicial — ya la cubrió load().
+            if (firstSnapshot) { firstSnapshot = false; return; }
+
+            const next = snapshot.docs
+              .map(d => normalizeFromFirestore({ id: d.id, ...d.data() }))
+              .sort((a, b) => (b.highlightScore || 0) - (a.highlightScore || 0));
+
+            // Short-circuit: si el contenido no cambió, no re-renderizamos.
+            if (contentHash(next) === contentHash(self._data)) return;
+
+            self._data = next;
+            cacheWrite(next);
+
+            // Debounce 500ms para agrupar ráfagas de cambios del admin.
+            clearTimeout(self._rtDebounce);
+            self._rtDebounce = setTimeout(() => {
+              console.log('[PropertyDB] Realtime update:', next.length, 'propiedades');
+              self._notify();
+              window.dispatchEvent(new CustomEvent('altorra:db-refreshed'));
+              showUpdateToast();
+            }, 500);
+          },
+          (err) => {
+            console.debug('[PropertyDB] realtime listener error:', err.code || err.message);
+            self._realtimeActive = false;
+          }
+        );
+      } catch (err) {
+        this._realtimeActive = false;
+        console.debug('[PropertyDB] No se pudo iniciar realtime:', err.message);
+      }
+    }
+
+    /** Detener la suscripción en tiempo real (opcional — útil al navegar SPA). */
+    stopRealtime() {
+      if (this._unsubRealtime) {
+        try { this._unsubRealtime(); } catch (_) {}
+        this._unsubRealtime = null;
+      }
+      this._realtimeActive = false;
     }
 
     /** Total de propiedades cargadas */

--- a/js/featured-week-banner.js
+++ b/js/featured-week-banner.js
@@ -196,12 +196,14 @@
 
   /* ─── Render o ocultar según DB viva ─────────────────────── */
   function renderFromDB(container, db) {
+    const section = container.closest('section');
     const prop = computeFeatured(db);
     if (!prop || !prop.id) {
-      // No hay destacada viva → limpiar cache y ocultar banner
+      // No hay destacada viva → limpiar cache y ocultar la sección entera
       try { localStorage.removeItem(CACHE_KEY); } catch {}
       container.innerHTML = '';
       container.style.display = 'none';
+      if (section) section.style.display = 'none';
       return;
     }
 
@@ -214,6 +216,7 @@
       }));
     } catch { /* ignore */ }
 
+    if (section) section.style.display = '';
     container.style.display = '';
     renderBanner(container, prop);
   }

--- a/js/historial-visitas.js
+++ b/js/historial-visitas.js
@@ -233,13 +233,24 @@
       ? document.querySelector(containerSel)
       : containerSel;
     if (!wrap) return;
+    const parentSection = wrap.closest('section');
+
+    const hide = () => {
+      wrap.innerHTML = '';
+      wrap.style.display = 'none';
+      if (parentSection) parentSection.style.display = 'none';
+    };
+    const show = () => {
+      wrap.style.display = '';
+      if (parentSection) parentSection.style.display = '';
+    };
 
     // Esperar DB y podar ítems obsoletos
     await waitForDB();
     const items = pruneAgainstDB().slice(0, limit);
-    if (!items.length) { wrap.style.display = 'none'; return; }
+    if (!items.length) { hide(); return; }
 
-    wrap.style.display = '';
+    show();
     wrap.innerHTML = `
       <section class="historial-section" aria-label="${title}">
         <h2>${title}</h2>
@@ -250,13 +261,19 @@
     // Re-render cuando Firestore traiga cambios (admin → público en vivo)
     if (!wrap._historialRefreshBound) {
       wrap._historialRefreshBound = true;
-      const onRefresh = () => {
-        const row = wrap.querySelector('.historial-row');
-        if (!row) return;
+      const onRefresh = async () => {
         const alive = pruneAgainstDB();
-        if (!alive.length) { wrap.style.display = 'none'; return; }
-        wrap.style.display = '';
-        render(row, limit);
+        if (!alive.length) { hide(); return; }
+        // Reconstruir la estructura si la sección estaba oculta
+        if (!wrap.querySelector('.historial-row')) {
+          wrap.innerHTML = `
+            <section class="historial-section" aria-label="${title}">
+              <h2>${title}</h2>
+              <div class="historial-row"></div>
+            </section>`;
+        }
+        show();
+        await render(wrap.querySelector('.historial-row'), limit);
       };
       window.addEventListener('altorra:db-refreshed', onRefresh);
       window.addEventListener('altorra:cache-invalidated', onRefresh);

--- a/js/listado-propiedades.js
+++ b/js/listado-propiedades.js
@@ -258,6 +258,17 @@
       renderedCount = 0;
       renderList(filteredProperties.slice(0, PAGE_SIZE), true);
       updateLoadMoreButton(filteredProperties.length);
+
+      // Empty state coherente con la carga inicial
+      if (filteredProperties.length === 0) {
+        const list = document.getElementById('list');
+        if (list) {
+          const msg = allProperties.length === 0
+            ? '<h3>Por el momento no hay propiedades disponibles en esta categoría</h3><p>Vuelve pronto — el catálogo se actualiza automáticamente.</p>'
+            : '<h3>No se encontraron propiedades</h3><p>Intenta ajustar los filtros de búsqueda.</p>';
+          list.innerHTML = '<div style="grid-column:1/-1;text-align:center;padding:40px;color:var(--muted)">' + msg + '</div>';
+        }
+      }
     };
     window.addEventListener('altorra:db-refreshed', reload);
     window.addEventListener('altorra:cache-invalidated', reload);
@@ -314,7 +325,10 @@
       if (filteredProperties.length === 0) {
         const list = document.getElementById('list');
         if (list) {
-          list.innerHTML = '<div style="grid-column:1/-1;text-align:center;padding:40px;color:var(--muted)"><h3>No se encontraron propiedades</h3><p>Intenta ajustar los filtros de búsqueda.</p></div>';
+          const msg = allProperties.length === 0
+            ? '<h3>Por el momento no hay propiedades disponibles en esta categoría</h3><p>Vuelve pronto — el catálogo se actualiza automáticamente.</p>'
+            : '<h3>No se encontraron propiedades</h3><p>Intenta ajustar los filtros de búsqueda.</p>';
+          list.innerHTML = '<div style="grid-column:1/-1;text-align:center;padding:40px;color:var(--muted)">' + msg + '</div>';
         }
       }
 

--- a/scripts.js
+++ b/scripts.js
@@ -452,53 +452,36 @@ document.addEventListener('DOMContentLoaded', function() {
     }
   }
 
-  document.addEventListener('DOMContentLoaded', async function(){
-    const tasks = cfg.map(function(c){ return fetchByOperation(c.operation).then(function(arr){ return {c, arr}; }); });
-    const results = await Promise.all(tasks);
-    results.forEach(function(pair){
-      const c = pair.c, arr = pair.arr;
-      const root = document.getElementById(c.targetId);
-      if(!root) return;
-      root.innerHTML = '';
-      let empty = root.parentElement && root.parentElement.querySelector('.empty-home-msg');
-      if(!empty){ root.insertAdjacentHTML('afterend','<p class="empty-home-msg" style="display:none;margin-top:12px;">Sin propiedades para mostrar.</p>'); empty = root.parentElement && root.parentElement.querySelector('.empty-home-msg'); }
-      if(arr.length===0){ if(empty) empty.style.display = 'block'; return; } else { if(empty) empty.style.display='none'; }
-      if(!arr.length){
-        const note = document.createElement('div');
-        note.style.padding='12px'; note.style.color='var(--muted)';
-        note.textContent = 'Sin propiedades para mostrar.';
-        root.appendChild(note);
+  // Renderizar un carrusel del home y ocultar la sección entera si no hay
+  // inventario (política: nunca mostrar un carrusel vacío con título).
+  function renderCarousel(c) {
+    const root = document.getElementById(c.targetId);
+    if (!root) return Promise.resolve();
+    const section = root.closest('section');
+    return fetchByOperation(c.operation).then(function(arr){
+      if (!arr || arr.length === 0) {
+        if (section) section.style.display = 'none';
+        root.innerHTML = '';
         return;
       }
-
-      /* === ORDEN INTELIGENTE === */
+      if (section) section.style.display = '';
+      root.innerHTML = '';
       const ordered = smartOrder(arr);
       ordered.slice(0,8).forEach(function(p){ root.appendChild(buildCard(p, c.mode)); });
-      // >>> Favoritos: re-init seguro para home
       if (window.AltorraFavoritos && typeof window.AltorraFavoritos.init === 'function') {
         try { window.AltorraFavoritos.init(); } catch(_){}
       }
       try { document.dispatchEvent(new CustomEvent('altorra:properties-loaded')); } catch(_){}
-
     });
+  }
 
-    // Refresco cada vez que Firestore trae datos nuevos (sin { once: true }
-    // para que admin → públic sea en tiempo real)
+  document.addEventListener('DOMContentLoaded', async function(){
+    await Promise.all(cfg.map(renderCarousel));
+
+    // Refresco cada vez que Firestore trae datos nuevos (sin { once: true })
+    // para que admin → público sea en tiempo real en todos los carruseles.
     function refreshCarousels() {
-      cfg.forEach(async function(c){
-        const root = document.getElementById(c.targetId);
-        if(!root) return;
-        const arr = await fetchByOperation(c.operation);
-        root.innerHTML = '';
-        const empty = root.parentElement && root.parentElement.querySelector('.empty-home-msg');
-        if(arr.length === 0){ if(empty) empty.style.display = 'block'; return; } else { if(empty) empty.style.display='none'; }
-        const ordered = smartOrder(arr);
-        ordered.slice(0,8).forEach(function(p){ root.appendChild(buildCard(p, c.mode)); });
-        if (window.AltorraFavoritos && typeof window.AltorraFavoritos.init === 'function') {
-          try { window.AltorraFavoritos.init(); } catch(_){}
-        }
-        try { document.dispatchEvent(new CustomEvent('altorra:properties-loaded')); } catch(_){}
-      });
+      cfg.forEach(function(c){ renderCarousel(c); });
     }
     window.addEventListener('altorra:db-refreshed', refreshCarousels);
     window.addEventListener('altorra:cache-invalidated', refreshCarousels);


### PR DESCRIPTION
Replica el patrón de Altorra Cars para sincronía instantánea y UI limpia:

• PropertyDatabase.startRealtime() — onSnapshot sobre la colección
  'propiedades' con debounce de 500ms y short-circuit por hash de contenido.
  Arranca automáticamente tras load(). Cualquier create/edit/delete en el
  admin (venta, arriendo, días, destacadas) se refleja en la web sin recargar.

• Toast sutil "Catálogo actualizado" al llegar cambios en vivo (throttle 3s,
  oculto en admin.html y en tabs en segundo plano).

• cache-manager.invalidate() ahora ESPERA a propertyDB.refresh() antes de
  disparar 'altorra:cache-invalidated' → los listeners ven datos frescos
  cuando re-consultan filter()/getById().

• PropertyDatabase.refresh() emite 'altorra:db-refreshed' al terminar para
  que todos los módulos (carruseles, listados, mapa, banner, historial,
  smart-search) se repinten.

• Home: secciones de Venta / Arriendo / Alojamientos ocultas (title + arrows
  + carrusel) cuando no hay inventario para esa operación — no se muestra 'sin propiedades'; simplemente desaparece la sección.

• Banner "Propiedad destacada de la semana": oculta la sección entera
  cuando no existe ninguna destacada viva.

• Historial "Vistas recientemente": oculta la sección entera cuando todas
  las visitas previas corresponden a propiedades ya eliminadas.

• Listings: mensajes de empty state diferenciados (sin inventario en la
  categoría vs. filtros sin resultados) y coherentes en live refresh.