### PR TITLE
fix(home): ocultar secciones vacías por defecto para evitar parpadeo

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,15 +116,13 @@
     </section>
 
     <!-- VENTA -->
-    <section class="section" aria-labelledby="venta-title">
+    <section class="section" aria-labelledby="venta-title" style="display:none">
       <div class="head">
         <h2 id="venta-title">Propiedades en <span style="color:var(--gold)">Venta</span></h2>
         <a href="propiedades-comprar.html">Ver todo →</a>
       </div>
       <div class="carousel-wrap">
-        <div id="carouselVenta" class="carousel-row" role="list">
-          <div class="loading" style="padding:12px;color:var(--muted)">Cargando propiedades...</div>
-        </div>
+        <div id="carouselVenta" class="carousel-row" role="list"></div>
         <button class="arrow left" type="button" data-target="carouselVenta" aria-label="Desplazar carrusel de venta a la izquierda">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor"><polyline points="15 18 9 12 15 6"/></svg>
         </button>
@@ -135,15 +133,13 @@
     </section>
 
     <!-- ARRIENDO -->
-    <section class="section" aria-labelledby="arrend-title" style="background:#fff">
+    <section class="section" aria-labelledby="arrend-title" style="background:#fff;display:none">
       <div class="head">
         <h2 id="arrend-title">Propiedades en <span style="color:var(--gold)">Arriendo</span></h2>
         <a href="propiedades-arrendar.html">Ver todo →</a>
       </div>
       <div class="carousel-wrap">
-        <div id="carouselArriendo" class="carousel-row" role="list">
-          <div class="loading" style="padding:12px;color:var(--muted)">Cargando propiedades...</div>
-        </div>
+        <div id="carouselArriendo" class="carousel-row" role="list"></div>
         <button class="arrow left" type="button" data-target="carouselArriendo" aria-label="Desplazar carrusel de arriendo a la izquierda">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor"><polyline points="15 18 9 12 15 6"/></svg>
         </button>
@@ -154,15 +150,13 @@
     </section>
 
     <!-- ALOJAMIENTOS -->
-    <section class="section" aria-labelledby="dias-title">
+    <section class="section" aria-labelledby="dias-title" style="display:none">
       <div class="head">
         <h2 id="dias-title">Alojamientos por <span style="color:var(--gold)">Días</span></h2>
         <a href="propiedades-alojamientos.html">Ver todo →</a>
       </div>
       <div class="carousel-wrap">
-        <div id="carouselDias" class="carousel-row" role="list">
-          <div class="loading" style="padding:12px;color:var(--muted)">Cargando propiedades...</div>
-        </div>
+        <div id="carouselDias" class="carousel-row" role="list"></div>
         <button class="arrow left" type="button" data-target="carouselDias" aria-label="Desplazar carrusel de alojamientos a la izquierda">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor"><polyline points="15 18 9 12 15 6"/></svg>
         </button>
@@ -173,7 +167,7 @@
     </section>
 
     <!-- BANNER DESTACADA DE LA SEMANA -->
-    <section class="section" style="background:#fffdf4;padding:32px 16px" aria-label="Propiedad destacada">
+    <section class="section" style="background:#fffdf4;padding:32px 16px;display:none" aria-label="Propiedad destacada">
       <div style="max-width:var(--page-max);margin:0 auto">
         <div class="head" style="margin-bottom:16px">
           <h2>Propiedad destacada <span style="color:var(--gold)">de la semana</span></h2>
@@ -183,7 +177,7 @@
     </section>
 
     <!-- HISTORIAL DE VISITAS -->
-    <section class="section" style="background:#fff" aria-label="Vistas recientemente">
+    <section class="section" style="background:#fff;display:none" aria-label="Vistas recientemente">
       <div id="historial-container" style="max-width:var(--page-max);margin:0 auto;padding:0 16px"></div>
     </section>
   </main>


### PR DESCRIPTION
Las secciones de Venta/Arriendo/Días/Destacada/Historial arrancan con display:none en el HTML. El JS las revela solo cuando Firestore trae datos reales — elimina el flash de "Cargando propiedades..." que se veía y desaparecía cuando no había inventario.

https://claude.ai/code/session_0164LKMpwraWjvfW86xJThAp