### PR TITLE
feat(ui): skeleton cards animadas mientras carga Firestore

### DIFF
--- a/js/listado-propiedades.js
+++ b/js/listado-propiedades.js
@@ -54,6 +54,36 @@
     return `https://wa.me/${WHATSAPP.phone}?text=${encodeURIComponent(text)}`;
   }
 
+  // Tarjeta skeleton de carga — shimmer mientras Firestore responde
+  function createSkeletonCard() {
+    const card = document.createElement('article');
+    card.className = 'card card--skeleton';
+    card.setAttribute('aria-hidden', 'true');
+    card.innerHTML = `
+      <div class="sk-media"></div>
+      <div class="sk-body">
+        <div class="sk-line w-80"></div>
+        <div class="sk-line w-50"></div>
+        <div class="sk-line w-60"></div>
+        <div class="sk-line w-40"></div>
+        <div class="sk-ctas">
+          <div class="sk-btn"></div>
+          <div class="sk-btn"></div>
+        </div>
+      </div>
+    `;
+    return card;
+  }
+
+  function renderSkeletons(count = 6) {
+    const root = document.getElementById('list');
+    if (!root) return;
+    root.innerHTML = '';
+    const fragment = document.createDocumentFragment();
+    for (let i = 0; i < count; i++) fragment.appendChild(createSkeletonCard());
+    root.appendChild(fragment);
+  }
+
   function createCard(p) {
     const card = document.createElement('article');
     card.className = 'card';
@@ -279,10 +309,10 @@
     const list = document.getElementById('list');
 
     if (counter) {
-      counter.innerHTML = '<span style="color:var(--muted)">⏳ Cargando propiedades...</span>';
+      counter.innerHTML = '<span style="color:var(--muted)">Cargando propiedades...</span>';
     }
     if (list) {
-      list.innerHTML = '<div style="grid-column:1/-1;text-align:center;padding:40px;color:var(--muted)"><p>⏳ Cargando propiedades...</p></div>';
+      renderSkeletons(PAGE_SIZE);
     }
 
     try {

--- a/scripts.js
+++ b/scripts.js
@@ -292,6 +292,28 @@ document.addEventListener('DOMContentLoaded', function() {
   function formatCOP(n){ if(n==null) return ''; return n.toString().replace(/\B(?=(\d{3})+(?!\d))/g,'.'); }
   function escapeHtml(s){ return String(s||'').replace(/[&<>"]/g, m=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[m])); }
 
+  // Skeleton cards mientras Firestore responde (reduce la sensación de pantalla vacía)
+  function buildSkeletonCard(){
+    const el = document.createElement('article');
+    el.className = 'card card--skeleton';
+    el.setAttribute('aria-hidden', 'true');
+    el.innerHTML = ''
+      + '<div class="sk-media"></div>'
+      + '<div class="sk-body">'
+      +   '<div class="sk-line w-80"></div>'
+      +   '<div class="sk-line w-50"></div>'
+      +   '<div class="sk-line w-60"></div>'
+      + '</div>';
+    return el;
+  }
+  function renderCarouselSkeletons(root, count){
+    if (!root) return;
+    root.innerHTML = '';
+    const frag = document.createDocumentFragment();
+    for (let i = 0; i < count; i++) frag.appendChild(buildSkeletonCard());
+    root.appendChild(frag);
+  }
+
   /* ===== Toast reutilizable para favoritos (estilo detalle) ===== */
   function showFavToast(added){
     try{
@@ -458,6 +480,10 @@ document.addEventListener('DOMContentLoaded', function() {
     const root = document.getElementById(c.targetId);
     if (!root) return Promise.resolve();
     const section = root.closest('section');
+    // Placeholders solo si aún no hay datos locales — evita flash en recargas con caché
+    if (!root.children.length && !(window.propertyDB && window.propertyDB.isLoaded)) {
+      renderCarouselSkeletons(root, 4);
+    }
     return fetchByOperation(c.operation).then(function(arr){
       if (!arr || arr.length === 0) {
         if (section) section.style.display = 'none';

--- a/style.css
+++ b/style.css
@@ -194,3 +194,63 @@ img[data-src].loaded {
     transition-duration: 0.01ms !important;
   }
 }
+
+/* ========================================
+   SKELETON CARDS — placeholders mientras cargan datos de Firestore
+   Se usan en listados (.grid #list) y en carruseles del home (.carousel-row)
+   Reutiliza @keyframes loading definido arriba.
+   ======================================== */
+.card--skeleton {
+  background: #fff;
+  border-radius: var(--card-radius, var(--card-r, 14px));
+  overflow: hidden;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.04);
+  display: flex;
+  flex-direction: column;
+  cursor: default;
+  pointer-events: none;
+  /* En carruseles horizontales necesita ancho mínimo como la card real */
+  min-width: 260px;
+}
+.card--skeleton:hover {
+  transform: none;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.04);
+}
+.card--skeleton .sk-media {
+  position: relative;
+  aspect-ratio: 4 / 3;
+  background: #eee;
+  overflow: hidden;
+}
+.card--skeleton .sk-body {
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.card--skeleton .sk-line,
+.card--skeleton .sk-media,
+.card--skeleton .sk-btn {
+  background: linear-gradient(90deg, #eee 25%, #f5f5f5 50%, #eee 75%);
+  background-size: 200% 100%;
+  animation: loading 1.4s linear infinite;
+}
+.card--skeleton .sk-line {
+  height: 12px;
+  border-radius: 6px;
+}
+.card--skeleton .sk-line.w-80 { width: 80%; }
+.card--skeleton .sk-line.w-60 { width: 60%; }
+.card--skeleton .sk-line.w-50 { width: 50%; }
+.card--skeleton .sk-line.w-40 { width: 40%; }
+.card--skeleton .sk-ctas {
+  display: flex;
+  gap: 8px;
+  margin-top: 4px;
+}
+.card--skeleton .sk-btn {
+  flex: 1;
+  height: 32px;
+  border-radius: 10px;
+}


### PR DESCRIPTION
Reemplaza el texto estático "⏳ Cargando propiedades..." por placeholders con shimmer en listados (#list) y carruseles del home. Reduce la sensación de pantalla vacía durante el await de PropertyDatabase sin afectar los tiempos de carga reales.

- style.css: añade .card--skeleton + .sk-media/.sk-line/.sk-btn reutilizando el @keyframes loading ya existente
- js/listado-propiedades.js: nueva renderSkeletons(PAGE_SIZE) inyectada en init() antes del waitForDB()
- scripts.js: skeletons en los 3 carruseles solo cuando propertyDB aún no está cargado (evita flash en recargas con caché)

https://claude.ai/code/session_013cRBqGpfZU1u63UcyrDTAR