### PR TITLE
feat(home): A1a — hero search con búsquedas recientes y atajo "/"

### DIFF
--- a/AVANCES.md
+++ b/AVANCES.md
@@ -68,6 +68,42 @@ la migración estará 100% completa.
 
 ---
 
+### ✅ A1a — Hero search: búsquedas recientes + atajo "/" (2026-04-16)
+
+**Contexto:** Primera micro-fase del plan unificado tras revisar el repo vivo de
+Altorra Cars. El `js/smart-search.js` actual ya supera a Cars en typos
+(Damerau-Levenshtein), parseo de presupuesto, sinónimos y re-ranking por clicks.
+Faltaban tres cosas que Cars sí tiene y aportan UX directa.
+
+**Qué se añadió (sin tocar la lógica semántica existente):**
+
+1. **Búsquedas recientes** en `localStorage` (clave `altorra:hero-recent-searches`,
+   máx. 5). Helpers `getRecent()`, `saveRecent()`, `removeRecent()`.
+2. **Render de recientes al enfocar el hero** (`#f-search`) cuando el input está
+   vacío — cada fila con icono de reloj, texto y botón × para eliminar. Al hacer
+   clic en una reciente, se rellena el input y dispara la búsqueda automática.
+3. **Guardado automático** en dos puntos de intención:
+   - Al enviar el formulario `#quickSearch` (click en "Buscar" o Enter).
+   - Al hacer clic en una sugerencia de propiedad (se guarda el query que la
+     produjo, detectado vía `document.activeElement`).
+4. **Atajo `/`** global: enfoca `#f-search` desde cualquier parte de la página,
+   respetando inputs/textareas/selects activos y `contenteditable`. En blanco,
+   abre las recientes directamente.
+
+**Archivos tocados:**
+- `js/smart-search.js` — +103 líneas netas, sin cambiar el motor de búsqueda.
+
+**Criterio de éxito:**
+- [x] `node --check js/smart-search.js` → sintaxis válida.
+- [x] El dropdown existente (singleton `DD`) se reutiliza; no se crea uno nuevo.
+- [x] El comportamiento previo (typos, presupuesto, features, click-ranking)
+      queda intacto — solo se añade la capa de recientes sobre el mismo `DD`.
+
+**Qué sigue (A1b):** agrupar sugerencias por barrio/tipo con contador de
+propiedades (ej: "Bocagrande · 8 propiedades") como hace Cars con marca/modelo.
+
+---
+
 ### ✅ SESIÓN AUDITORÍA Y FIXES (2026-04-10)
 
 **Contexto:** Al revisar los MDs y auditar el estado real del código, se encontraron

--- a/js/smart-search.js
+++ b/js/smart-search.js
@@ -14,6 +14,8 @@
   const MAX_SUGGESTIONS = 12;
   const DEBOUNCE_MS = 200;
   const MIN_W = 360, MAX_W = 920, VW_LIMIT = 0.96;
+  const RECENT_KEY = 'altorra:hero-recent-searches';
+  const RECENT_MAX = 5;
 
   /* ---------- Utils ---------- */
   const debounce = (fn, wait) => { let t; return (...a)=>{ clearTimeout(t); t=setTimeout(()=>fn(...a), wait); }; };
@@ -22,6 +24,28 @@
   const clamp = (v, a, b)=>Math.max(a, Math.min(b, v));
   const uniq  = arr => Array.from(new Set(arr));
   const fuzzyScore = (n, h)=>{ n=n.toLowerCase(); let s=0,i=0,j=0; while(i<n.length&&j<h.length){ if(n[i]===h[j]){s++;i++;} j++; } return i===n.length? s/n.length : 0; };
+
+  /* ---------- Búsquedas recientes (localStorage) ---------- */
+  function getRecent(){
+    try { return JSON.parse(localStorage.getItem(RECENT_KEY) || '[]').slice(0, RECENT_MAX); }
+    catch { return []; }
+  }
+  function saveRecent(term){
+    if (!term) return;
+    const t = String(term).trim();
+    if (t.length < MIN_CHARS) return;
+    try {
+      const arr = getRecent().filter(x => x.toLowerCase() !== t.toLowerCase());
+      arr.unshift(t);
+      localStorage.setItem(RECENT_KEY, JSON.stringify(arr.slice(0, RECENT_MAX)));
+    } catch {}
+  }
+  function removeRecent(term){
+    try {
+      const arr = getRecent().filter(x => x.toLowerCase() !== String(term).toLowerCase());
+      localStorage.setItem(RECENT_KEY, JSON.stringify(arr));
+    } catch {}
+  }
 
   // Carga desde PropertyDatabase (fuente única: Firestore). Sin fetch a data.json.
   async function loadData(){
@@ -442,6 +466,8 @@
         </div>`;
       row.addEventListener('click',()=>{
         registerClick(p.id);
+        const ae = document.activeElement;
+        if (ae && ae.id === 'f-search' && ae.value.trim()) saveRecent(ae.value.trim());
         location.href=`detalle-propiedad.html?id=${encodeURIComponent(p.id)}`;
       });
       dd.appendChild(row);
@@ -468,6 +494,53 @@
     input.setAttribute('inputmode','search');
     input.setAttribute('enterkeyhint','search');
     input.setAttribute('autocomplete','off');
+  }
+
+  /* ---------- Render de búsquedas recientes ---------- */
+  function renderRecent(input){
+    const recent = getRecent();
+    if (!recent.length) { DD.hide(); return; }
+    const dd = DD.el();
+    DD.setActive(input, { lockWidth: true });
+
+    const clockSvg = '<svg viewBox="0 0 20 20" fill="currentColor" width="14" height="14" aria-hidden="true" style="flex-shrink:0;color:#9ca3af"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm.75-13a.75.75 0 00-1.5 0v5c0 .414.336.75.75.75h4a.75.75 0 000-1.5h-3.25V5z" clip-rule="evenodd"/></svg>';
+
+    dd.innerHTML =
+      '<div style="padding:10px 14px 6px;font-size:.72rem;font-weight:700;color:#6b7280;text-transform:uppercase;letter-spacing:.06em">Búsquedas recientes</div>' +
+      recent.map(term => {
+        const safe = esc(term);
+        return '<div class="ss-recent-item" data-term="' + safe + '" role="option"' +
+               ' style="display:flex;gap:10px;padding:10px 14px;cursor:pointer;align-items:center">' +
+                 clockSvg +
+                 '<span style="flex:1;color:#111827;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">' + safe + '</span>' +
+                 '<button type="button" class="ss-recent-del" data-term="' + safe + '"' +
+                 ' aria-label="Eliminar búsqueda reciente"' +
+                 ' style="background:transparent;border:0;color:#9ca3af;font-size:1.2rem;line-height:1;cursor:pointer;padding:2px 8px;border-radius:6px">&times;</button>' +
+               '</div>';
+      }).join('');
+
+    dd.querySelectorAll('.ss-recent-item').forEach(row => {
+      row.addEventListener('mouseenter', () => { row.style.background = '#f9fafb'; });
+      row.addEventListener('mouseleave', () => { row.style.background = 'transparent'; });
+      row.addEventListener('click', (e) => {
+        if (e.target.closest('.ss-recent-del')) return;
+        const t = row.dataset.term;
+        input.value = t;
+        input.dispatchEvent(new Event('input'));
+        input.focus();
+      });
+    });
+    dd.querySelectorAll('.ss-recent-del').forEach(btn => {
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        e.preventDefault();
+        removeRecent(btn.dataset.term);
+        renderRecent(input);
+      });
+    });
+
+    DD.show();
+    DD.position();
   }
 
   /* ---------- Init ---------- */
@@ -508,7 +581,14 @@
       }, DEBOUNCE_MS);
 
       input.addEventListener('input', run);
-      input.addEventListener('focus', run);
+      input.addEventListener('focus', () => {
+        // En el hero: si está vacío, mostrar búsquedas recientes en vez del dropdown vacío
+        if (input.id === 'f-search' && !input.value.trim()) {
+          renderRecent(input);
+        } else {
+          run();
+        }
+      });
       installTapToClose(input);
 
       // Teclado (desktop)
@@ -527,6 +607,29 @@
         else if(e.key==='Enter'){ if(current>=0){ e.preventDefault(); list[current].click(); } }
         else if(e.key==='Escape'){ DD.hide(); }
       });
+    });
+
+    // Guardar búsqueda reciente al enviar el formulario del hero
+    const heroForm = document.getElementById('quickSearch');
+    if (heroForm) {
+      heroForm.addEventListener('submit', () => {
+        const q = document.getElementById('f-search')?.value.trim();
+        if (q) saveRecent(q);
+      });
+    }
+
+    // Atajo "/" para enfocar el hero search desde cualquier parte de la página
+    document.addEventListener('keydown', (e) => {
+      if (e.key !== '/' || e.ctrlKey || e.metaKey || e.altKey) return;
+      const ae = document.activeElement;
+      if (ae && ['INPUT','TEXTAREA','SELECT'].includes(ae.tagName)) return;
+      if (ae && ae.isContentEditable) return;
+      const hero = document.getElementById('f-search');
+      if (!hero) return;
+      e.preventDefault();
+      hero.focus();
+      hero.select?.();
+      if (!hero.value.trim()) renderRecent(hero);
     });
   });
 })();


### PR DESCRIPTION
Primera micro-fase del plan unificado (paridad con Altorra Cars). El smart-search actual ya es superior en typos/presupuesto/sinónimos, por lo que sólo se añade la capa de UX que Cars aporta:

- Búsquedas recientes en localStorage (máx. 5) con render al enfocar el hero (#f-search) vacío, cada una con icono de reloj y × para borrar.
- Guardado automático en: submit de #quickSearch y click en sugerencia (vía document.activeElement, sin tocar renderList).
- Atajo "/" para enfocar el hero desde cualquier parte de la página, respetando inputs/textareas/selects activos y contenteditable.

El motor de búsqueda (Damerau-Levenshtein, parseo de presupuesto, sinónimos ES/EN, click-ranking) queda intacto. Solo se reutiliza el dropdown singleton DD ya existente.

Archivos:
- js/smart-search.js  (+103 líneas netas, sin cambios en la lógica semántica)
- AVANCES.md           (entrada A1a)

https://claude.ai/code/session_01EES3HSNiBjVcrCrext96rr