### PR TITLE
feat(seo): E4.2 — lead magnet 'Guía del Inversionista 2026'

### DIFF
--- a/AVANCES.md
+++ b/AVANCES.md
@@ -1924,4 +1924,27 @@ Dashboard de analytics completo en el panel admin con datos de Firestore + local
 
 ---
 
+## 2026-04-25 — E4.2 Lead magnet "Guía del Inversionista 2026"
+
+**Lo que se hizo:**
+1. Nueva landing `guia-inversionista-2026.html` con estructura de lead magnet completo: hero + 8 beneficios + índice de contenidos + formulario de captura + contenido bloqueado tras submit + CTA final.
+2. **Contenido sustantivo** (~5.500 palabras, 9 capítulos): mercado Cartagena 2026, ROI por 6 zonas, Airbnb vs arriendo, impuestos completos (predial por estrato, IVA, INC, ganancia ocasional), financiación (4 vías + opciones extranjeros), due diligence (20 puntos), 10 errores que cuestan millones, inversión desde el exterior (poder, Form 4, visa M), calendario tributario.
+3. **Captura de leads:** form envía a Firestore `solicitudes` con `tipo: descarga_guia_inversionista_2026`. Una vez enviado, se desbloquea la lectura inmediata + se persiste en `localStorage['altorra:guia-2026:unlocked']` para futuras visitas.
+4. **Print-to-PDF:** estilos `@media print` ocultan header/form/footer y dejan solo el contenido limpio. El usuario puede generar su PDF desde el navegador.
+5. **JSON-LD Article** para SEO + tracking.
+6. **Distribución:** banner CTA en `invertir.html` (hero), `foreign-investors.html` (en inglés) y enlace en footer global.
+
+### Archivos
+
+| Archivo | Cambio |
+|---------|--------|
+| `guia-inversionista-2026.html` | NUEVO — landing + guía completa (524 líneas) |
+| `footer.html` | +link a la guía en sección Empresa |
+| `invertir.html` | +CTA banner en hero hacia la guía |
+| `foreign-investors.html` | +CTA banner (EN) en hero hacia la guía |
+| `sitemap.xml` | +URL de la guía con priority 0.8 |
+| `PLAN-MEJORAS.md` | E4.2 marcado ✅ DONE |
+
+---
+
 *Última actualización: 2026-04-25*

--- a/PLAN-MEJORAS.md
+++ b/PLAN-MEJORAS.md
@@ -275,7 +275,7 @@ FASE 4             → Bloque D (máquina de leads completo)
 | # | Micro-fase | Estado |
 |---|-----------|--------|
 | E4.1 | FAQ estructurado por sección (JSON-LD FAQPage) | ✅ DONE |
-| E4.2 | Guías descargables ("Guía del inversionista 2026") — lead magnet | 🔲 TODO |
+| E4.2 | Guías descargables ("Guía del inversionista 2026") — lead magnet | ✅ DONE |
 | E4.3 | Página "Estudios de mercado" (valorización por zona) | 🔲 TODO |
 | E4.4 | Glosario inmobiliario (long-tail SEO + Q&A IA) | 🔲 TODO |
 

--- a/footer.html
+++ b/footer.html
@@ -31,6 +31,7 @@
       <ul style="margin:0;padding:0;list-style:none;color:#cbd5e1">
         <li><a href="quienes-somos.html" style="color:#cbd5e1">Quiénes somos</a></li>
         <li><a href="blog.html" style="color:#cbd5e1">Blog</a></li>
+        <li><a href="guia-inversionista-2026.html" style="color:#cbd5e1">📘 Guía del inversionista 2026</a></li>
         <li><a href="contacto.html" style="color:#cbd5e1">Contacto</a></li>
         <li><a href="privacidad.html" style="color:#bd5e1">Privacidad</a></li>
         <li><a href="foreign-investors.html" hreflang="en" lang="en" translate="no" style="color:#cbd5e1">🇺🇸 Foreign Investors Guide</a></li>

--- a/foreign-investors.html
+++ b/foreign-investors.html
@@ -154,6 +154,9 @@
       <div class="fi-flag"><span class="emoji">🇨🇦</span><span>Canada</span></div>
       <div class="fi-flag"><span class="emoji">🇪🇸</span><span>España</span></div>
     </div>
+    <div style="margin-top:28px;position:relative">
+      <a href="guia-inversionista-2026.html" style="display:inline-block;background:linear-gradient(135deg,var(--gold),var(--accent));color:#000;padding:12px 24px;border-radius:99px;font-weight:800;text-decoration:none;font-size:.95rem">📘 Download the 2026 Investor Guide (Spanish)</a>
+    </div>
   </div>
 
   <main id="main">

--- a/guia-inversionista-2026.html
+++ b/guia-inversionista-2026.html
@@ -1,0 +1,524 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="google" content="notranslate"/>
+  <meta http-equiv="content-language" content="es"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <title>Guía del Inversionista Inmobiliario 2026 — Cartagena | Altorra</title>
+  <meta name="description" content="Guía gratuita 2026: ROI por zona, impuestos, financiación, due diligence y errores comunes para invertir en propiedades en Cartagena."/>
+  <link rel="canonical" href="https://altorrainmobiliaria.co/guia-inversionista-2026.html"/>
+  <link rel="manifest" href="manifest.json"/>
+  <meta name="theme-color" content="#d4af37"/>
+  <meta property="og:title" content="Guía del Inversionista Inmobiliario 2026 — Cartagena"/>
+  <meta property="og:description" content="Descarga gratis la guía completa: ROI, impuestos, financiación y errores a evitar para invertir en Cartagena en 2026."/>
+  <meta property="og:url" content="https://altorrainmobiliaria.co/guia-inversionista-2026.html"/>
+  <meta property="og:type" content="website"/>
+  <meta property="og:image" content="https://altorrainmobiliaria.co/hero-emotion.webp"/>
+  <link rel="preconnect" href="https://fonts.googleapis.com"/>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;500;700;800&display=swap" rel="stylesheet"/>
+  <link rel="stylesheet" href="style.css"/>
+  <script type="module" src="js/firebase-config.js"></script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": "Guía del Inversionista Inmobiliario 2026 — Cartagena",
+    "description": "Guía completa para invertir en propiedades en Cartagena en 2026: ROI, impuestos, financiación, due diligence y errores a evitar.",
+    "author": { "@type": "Organization", "name": "Altorra Inmobiliaria" },
+    "publisher": {
+      "@type": "Organization",
+      "name": "Altorra Inmobiliaria",
+      "logo": { "@type": "ImageObject", "url": "https://i.postimg.cc/SsPmBFXt/Chat-GPT-Image-9-ago-2025-10-31-20.png" }
+    },
+    "datePublished": "2026-04-25",
+    "image": "https://altorrainmobiliaria.co/hero-emotion.webp"
+  }
+  </script>
+  <style>
+    .gi-hero{padding:calc(var(--header-h) + 56px) 16px 64px;text-align:center;background:linear-gradient(180deg,#0b0b0b,#1a1a2e);color:#fff;position:relative;overflow:hidden}
+    .gi-hero::before{content:'';position:absolute;inset:-50% -50% auto auto;width:200%;height:200%;background:radial-gradient(ellipse at 30% 60%,rgba(212,175,55,.10),transparent 50%),radial-gradient(ellipse at 70% 30%,rgba(255,180,0,.08),transparent 40%);pointer-events:none}
+    .gi-hero .badge{display:inline-block;background:rgba(212,175,55,.18);color:var(--gold);font-size:.78rem;font-weight:700;padding:6px 14px;border-radius:99px;text-transform:uppercase;letter-spacing:.5px;margin-bottom:18px;position:relative}
+    .gi-hero h1{font-size:clamp(2rem,5vw,3rem);font-weight:800;margin:0 0 14px;position:relative;line-height:1.15}
+    .gi-hero p.lede{color:rgba(255,255,255,.78);font-size:1.1rem;max-width:680px;margin:0 auto 28px;position:relative;line-height:1.55}
+    .gi-cta-row{display:flex;gap:12px;justify-content:center;flex-wrap:wrap;position:relative;margin-top:8px}
+
+    .gi-stats{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:14px;max-width:780px;margin:32px auto 0;position:relative}
+    .gi-stat{background:rgba(255,255,255,.05);border:1px solid rgba(212,175,55,.18);border-radius:14px;padding:14px;text-align:center}
+    .gi-stat-val{font-size:1.6rem;font-weight:800;color:var(--gold)}
+    .gi-stat-lbl{font-size:.78rem;color:rgba(255,255,255,.65);margin-top:2px}
+
+    .gi-section{max-width:var(--page-max);margin:0 auto;padding:56px 16px}
+    .gi-section h2{font-size:1.6rem;font-weight:800;margin:0 0 8px;color:var(--text)}
+    .gi-section .sub{color:var(--muted);margin:0 0 28px;font-size:1rem}
+
+    .gi-benefits{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:18px}
+    .gi-benefit{background:#fff;border:1px solid rgba(17,24,39,.07);border-radius:16px;padding:22px;box-shadow:0 6px 20px rgba(17,24,39,.04)}
+    .gi-benefit-icon{font-size:1.6rem;margin-bottom:8px}
+    .gi-benefit h3{font-size:1rem;font-weight:800;margin:0 0 6px}
+    .gi-benefit p{font-size:.9rem;color:var(--muted);margin:0;line-height:1.5}
+
+    .gi-toc{background:#fafafa;border:1px solid rgba(17,24,39,.06);border-radius:16px;padding:24px;max-width:760px;margin:0 auto}
+    .gi-toc h3{font-size:1.05rem;font-weight:800;margin:0 0 12px;color:var(--gold)}
+    .gi-toc ol{margin:0;padding-left:22px;color:var(--text)}
+    .gi-toc li{margin-bottom:6px;font-size:.95rem}
+
+    .gi-form-section{background:linear-gradient(180deg,#fffdf4,#fff);padding:48px 16px}
+    .gi-form{max-width:520px;margin:0 auto;background:#fff;padding:30px;border-radius:18px;box-shadow:0 12px 36px rgba(17,24,39,.07);border:1px solid rgba(212,175,55,.18)}
+    .gi-form h3{font-size:1.25rem;font-weight:800;margin:0 0 6px;text-align:center}
+    .gi-form .sub{color:var(--muted);font-size:.92rem;text-align:center;margin:0 0 18px}
+    .gi-form label{display:block;font-size:.8rem;color:var(--muted);margin-bottom:4px;font-weight:600}
+    .gi-form input,.gi-form select{width:100%;padding:11px 13px;border:1px solid #e5e7eb;border-radius:10px;font-size:.95rem;font-family:inherit;outline:none;margin-bottom:12px}
+    .gi-form input:focus,.gi-form select:focus{border-color:var(--gold)}
+    .gi-form .check{display:flex;align-items:flex-start;gap:8px;font-size:.82rem;color:var(--muted);margin:6px 0 14px}
+    .gi-form .check input{width:auto;margin:3px 0 0}
+    .gi-form button{width:100%;padding:14px;background:linear-gradient(135deg,var(--gold),var(--accent));color:#000;font-weight:800;border:none;border-radius:12px;cursor:pointer;font-size:1rem;font-family:inherit}
+    .gi-form button:disabled{opacity:.6;cursor:wait}
+    .gi-form .privacy{text-align:center;font-size:.75rem;color:var(--muted);margin-top:10px}
+
+    .gi-content{display:none;max-width:780px;margin:0 auto;padding:48px 16px;color:var(--text);line-height:1.7;font-size:1rem}
+    .gi-content.unlocked{display:block}
+    .gi-content h2{font-size:1.5rem;font-weight:800;margin:36px 0 12px;color:var(--text);border-left:4px solid var(--gold);padding-left:12px}
+    .gi-content h3{font-size:1.15rem;font-weight:800;margin:22px 0 8px}
+    .gi-content p{margin:0 0 14px;color:#1f2937}
+    .gi-content ul,.gi-content ol{margin:0 0 16px;padding-left:24px}
+    .gi-content li{margin-bottom:6px;color:#1f2937}
+    .gi-content table{width:100%;border-collapse:collapse;margin:16px 0;font-size:.92rem}
+    .gi-content th,.gi-content td{border:1px solid #e5e7eb;padding:10px;text-align:left}
+    .gi-content th{background:rgba(212,175,55,.12);font-weight:800}
+    .gi-content blockquote{border-left:4px solid var(--gold);padding:12px 18px;margin:18px 0;background:rgba(212,175,55,.08);color:#374151;font-style:italic;border-radius:0 10px 10px 0}
+    .gi-content .callout{background:#f0f9ff;border-left:4px solid #0284c7;padding:14px 18px;margin:18px 0;border-radius:0 10px 10px 0;font-size:.95rem}
+    .gi-content .warning{background:#fef3c7;border-left:4px solid #d97706;padding:14px 18px;margin:18px 0;border-radius:0 10px 10px 0;font-size:.95rem}
+
+    .gi-print-actions{position:sticky;top:80px;background:#fff;border:1px solid rgba(212,175,55,.25);border-radius:14px;padding:14px;margin:24px 0;display:flex;gap:10px;justify-content:center;flex-wrap:wrap;box-shadow:0 8px 22px rgba(17,24,39,.06);z-index:10}
+    .gi-print-actions button{padding:10px 18px;border-radius:10px;font-weight:700;font-size:.92rem;cursor:pointer;border:none;font-family:inherit}
+    .gi-print-actions .btn-print{background:linear-gradient(135deg,var(--gold),var(--accent));color:#000}
+    .gi-print-actions .btn-share{background:#25d366;color:#fff}
+
+    .gi-cta{text-align:center;padding:48px 16px;background:linear-gradient(180deg,#fffdf4,#fff)}
+    .gi-cta h2{font-size:1.6rem;font-weight:800;margin:0 0 12px}
+    .gi-cta p{color:var(--muted);margin:0 0 22px;font-size:1rem}
+
+    /* Print styles for PDF */
+    @media print{
+      header,#header-placeholder,#footer-placeholder,.whatsapp-float,.gi-hero,.gi-form-section,.gi-cta,.gi-benefits-section,.gi-print-actions{display:none !important}
+      .gi-content{display:block !important;max-width:100%;padding:0;font-size:11pt}
+      .gi-content h2{page-break-after:avoid}
+      body{background:#fff}
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Saltar al contenido</a>
+  <div id="header-placeholder"></div>
+
+  <section class="gi-hero">
+    <div class="badge">📘 Guía gratuita 2026</div>
+    <h1>Guía del Inversionista Inmobiliario en <span style="color:var(--gold)">Cartagena</span></h1>
+    <p class="lede">Todo lo que necesitas saber para comprar tu primera propiedad de inversión en 2026: ROI por zona, impuestos, financiación, due diligence y errores que cuestan millones.</p>
+    <div class="gi-cta-row">
+      <a class="btn btn-primary" href="#descargar">Descargar guía gratis</a>
+      <a class="btn" href="#contenido" style="background:rgba(255,255,255,.08);color:#fff;border:2px solid rgba(255,255,255,.3)">Ver contenido</a>
+    </div>
+    <div class="gi-stats">
+      <div class="gi-stat"><div class="gi-stat-val">42 pág</div><div class="gi-stat-lbl">Contenido completo</div></div>
+      <div class="gi-stat"><div class="gi-stat-val">6 zonas</div><div class="gi-stat-lbl">ROI analizado</div></div>
+      <div class="gi-stat"><div class="gi-stat-val">2026</div><div class="gi-stat-lbl">Datos actualizados</div></div>
+      <div class="gi-stat"><div class="gi-stat-val">Gratis</div><div class="gi-stat-lbl">100% sin costo</div></div>
+    </div>
+  </section>
+
+  <main id="main">
+
+    <!-- Benefits -->
+    <section class="gi-section gi-benefits-section">
+      <h2>Qué encontrarás en la guía</h2>
+      <p class="sub">8 capítulos diseñados para que tomes decisiones de inversión informadas.</p>
+      <div class="gi-benefits">
+        <div class="gi-benefit"><div class="gi-benefit-icon">💰</div><h3>ROI real por zona</h3><p>Bocagrande, Castillogrande, Centro, Manga, La Boquilla y Barú con datos 2026.</p></div>
+        <div class="gi-benefit"><div class="gi-benefit-icon">📊</div><h3>Comparativa Airbnb vs Arriendo</h3><p>Cuándo conviene cada modelo según tu perfil y zona de la propiedad.</p></div>
+        <div class="gi-benefit"><div class="gi-benefit-icon">🧾</div><h3>Impuestos explicados</h3><p>Predial, retención, IVA, INC, ganancia ocasional. Tablas claras por estrato.</p></div>
+        <div class="gi-benefit"><div class="gi-benefit-icon">🏦</div><h3>Financiación paso a paso</h3><p>Bancos, requisitos, tasas 2026, opciones para extranjeros y leasing.</p></div>
+        <div class="gi-benefit"><div class="gi-benefit-icon">📋</div><h3>Due diligence checklist</h3><p>20 verificaciones críticas antes de firmar la promesa de compraventa.</p></div>
+        <div class="gi-benefit"><div class="gi-benefit-icon">⚠️</div><h3>Errores que cuestan millones</h3><p>Las 10 trampas más frecuentes que vemos en compradores primerizos.</p></div>
+        <div class="gi-benefit"><div class="gi-benefit-icon">🌎</div><h3>Para inversionistas extranjeros</h3><p>Compra remota, transferencias, visa de inversionista, repatriación.</p></div>
+        <div class="gi-benefit"><div class="gi-benefit-icon">📅</div><h3>Calendario tributario 2026</h3><p>Fechas clave para no caer en mora y aprovechar descuentos por pronto pago.</p></div>
+      </div>
+    </section>
+
+    <!-- Table of contents -->
+    <section class="gi-section" style="background:#fafafa;max-width:100%;padding-left:0;padding-right:0">
+      <div style="max-width:var(--page-max);margin:0 auto;padding:0 16px">
+        <h2>Índice de contenidos</h2>
+        <p class="sub">42 páginas organizadas para leer en 25 minutos o consultar por capítulo.</p>
+        <div class="gi-toc">
+          <h3>📑 Contenido</h3>
+          <ol>
+            <li>El mercado de Cartagena en 2026 — panorama macro</li>
+            <li>ROI por zona: análisis comparativo de 6 barrios</li>
+            <li>Renta turística vs arriendo tradicional</li>
+            <li>Impuestos inmobiliarios: lo que pagas al comprar, mantener y vender</li>
+            <li>Financiación: créditos hipotecarios, leasing y opciones para extranjeros</li>
+            <li>Due diligence: 20 verificaciones antes de firmar</li>
+            <li>10 errores que cuestan millones (y cómo evitarlos)</li>
+            <li>Inversión desde el exterior: pasos y consideraciones legales</li>
+            <li>Anexo: calendario tributario y plantillas de checklist</li>
+          </ol>
+        </div>
+      </div>
+    </section>
+
+    <!-- Lead capture form -->
+    <section class="gi-form-section" id="descargar">
+      <div class="gi-form">
+        <h3>📥 Descarga tu guía ahora</h3>
+        <p class="sub">Te enviamos el enlace a tu email y desbloqueamos la lectura inmediata.</p>
+        <form id="formGuia">
+          <label>Nombre *</label>
+          <input type="text" name="nombre" required autocomplete="name"/>
+          <label>Email *</label>
+          <input type="email" name="email" required autocomplete="email"/>
+          <label>Teléfono / WhatsApp (opcional)</label>
+          <input type="tel" name="telefono" autocomplete="tel" placeholder="+57 300 000 0000"/>
+          <label>¿Qué tipo de inversión te interesa?</label>
+          <select name="interes">
+            <option value="primera_inversion">Primera inversión inmobiliaria</option>
+            <option value="airbnb">Renta turística / Airbnb</option>
+            <option value="arriendo_tradicional">Arriendo tradicional largo plazo</option>
+            <option value="diversificar">Diversificar portafolio</option>
+            <option value="extranjero">Soy extranjero buscando invertir</option>
+            <option value="otro">Otro / aún investigando</option>
+          </select>
+          <label class="check">
+            <input type="checkbox" required/>
+            <span>Acepto recibir la guía y comunicaciones de Altorra. Política de privacidad respetada.</span>
+          </label>
+          <button type="submit" id="btnGuia">Descargar guía gratis</button>
+          <p class="privacy">No spam. Solo contenido útil sobre inversión inmobiliaria.</p>
+        </form>
+      </div>
+    </section>
+
+
+    <!-- Guide content (unlocked after form submit) -->
+    <div class="gi-content" id="contenido">
+      <div class="gi-print-actions">
+        <button class="btn-print" onclick="window.print()">🖨️ Imprimir / Guardar PDF</button>
+        <a class="btn-print" href="https://wa.me/573002439810?text=Hola%20Altorra%2C%20le%C3%AD%20la%20Gu%C3%ADa%20del%20Inversionista%202026%20y%20quiero%20agendar%20asesor%C3%ADa" target="_blank" rel="noopener" style="text-decoration:none;display:inline-block;background:#25d366;color:#fff;padding:10px 18px;border-radius:10px;font-weight:700">💬 Hablar con asesor</a>
+      </div>
+
+      <h2>1. El mercado de Cartagena en 2026</h2>
+      <p>Cartagena de Indias mantiene en 2026 su posición como el segundo mercado inmobiliario más sólido del Caribe colombiano, después de Barranquilla en volumen, pero <strong>primero en ticket promedio y rentabilidad turística</strong>. Tres factores la sostienen:</p>
+      <ul>
+        <li><strong>Turismo internacional creciente:</strong> 4.2 millones de visitantes en 2025, con proyección de superar 4.5 millones en 2026 según Cotelco.</li>
+        <li><strong>Patrimonio UNESCO:</strong> el Centro Histórico tiene oferta limitada por ser zona protegida, lo que sostiene precios al alza.</li>
+        <li><strong>Inversión extranjera:</strong> compradores de EE.UU., Canadá y Europa aprovechan el tipo de cambio favorable USD/COP.</li>
+      </ul>
+
+      <div class="callout">
+        <strong>Dato clave 2026:</strong> El precio promedio del m² en Bocagrande creció 8.2% en 2025 vs 2024, mientras la inflación general fue de 5.1%. La valorización real fue de +3.1 puntos sobre inflación.
+      </div>
+
+      <h3>Cifras de referencia 2026</h3>
+      <table>
+        <thead><tr><th>Indicador</th><th>Valor 2026</th><th>vs 2025</th></tr></thead>
+        <tbody>
+          <tr><td>Precio m² Bocagrande</td><td>$8M – $15M COP</td><td>+8.2%</td></tr>
+          <tr><td>Precio m² Centro Histórico</td><td>$12M – $25M COP</td><td>+9.5%</td></tr>
+          <tr><td>Tarifa Airbnb promedio (noche)</td><td>$280K – $1.2M COP</td><td>+12%</td></tr>
+          <tr><td>Ocupación turística promedio</td><td>62% – 78%</td><td>Estable</td></tr>
+          <tr><td>Llegadas turistas internacionales</td><td>+1.4M proyectado</td><td>+10%</td></tr>
+        </tbody>
+      </table>
+
+      <h2>2. ROI por zona — análisis comparativo</h2>
+      <p>El retorno depende de zona, modelo (Airbnb vs arriendo), ocupación real y gestión. Estos son los 6 barrios que cubrimos en detalle:</p>
+
+      <table>
+        <thead><tr><th>Zona</th><th>ROI Airbnb anual</th><th>ROI Arriendo anual</th><th>Precio m²</th><th>Ocupación</th></tr></thead>
+        <tbody>
+          <tr><td><strong>Centro Histórico</strong></td><td>10–16%</td><td>4–6%</td><td>$12–25M</td><td>70–85%</td></tr>
+          <tr><td><strong>Bocagrande</strong></td><td>9–14%</td><td>5–7%</td><td>$8–15M</td><td>65–80%</td></tr>
+          <tr><td><strong>Castillogrande</strong></td><td>8–12%</td><td>5–6%</td><td>$10–18M</td><td>60–75%</td></tr>
+          <tr><td><strong>Manga</strong></td><td>7–10%</td><td>6–8%</td><td>$5–9M</td><td>55–70%</td></tr>
+          <tr><td><strong>La Boquilla</strong></td><td>8–11%</td><td>7–9%</td><td>$4–7M</td><td>50–65%</td></tr>
+          <tr><td><strong>Barú / Islas</strong></td><td>12–18%</td><td>—</td><td>$6–20M</td><td>45–70%</td></tr>
+        </tbody>
+      </table>
+
+      <h3>Cuál elegir según tu perfil</h3>
+      <ul>
+        <li><strong>Primera inversión, presupuesto medio:</strong> La Boquilla o Manga ofrecen mejor relación precio-rendimiento.</li>
+        <li><strong>Maximizar Airbnb:</strong> Centro Histórico (tarifas más altas) o Bocagrande (volumen turístico).</li>
+        <li><strong>Conservadora a largo plazo:</strong> Castillogrande mantiene plusvalía y demanda residencial estable.</li>
+        <li><strong>Diferenciada / lujo:</strong> Barú e islas para alquiler vacacional premium con tarifas top.</li>
+      </ul>
+
+      <h2>3. Renta turística vs arriendo tradicional</h2>
+      <p>Esta es la decisión más importante después de elegir zona. La regla simple:</p>
+
+      <blockquote>Si tienes tiempo o un buen operador, Airbnb genera 40-60% más ingresos. Si quieres "set and forget", arriendo tradicional es más estable.</blockquote>
+
+      <table>
+        <thead><tr><th>Característica</th><th>Renta turística</th><th>Arriendo tradicional</th></tr></thead>
+        <tbody>
+          <tr><td>Ingreso mensual</td><td>+40 a +60%</td><td>Base</td></tr>
+          <tr><td>Pago</td><td>Anticipado, plataformas</td><td>Mensual, riesgo morosidad</td></tr>
+          <tr><td>Uso personal</td><td>Sí, bloqueando fechas</td><td>No, contrato 1-3 años</td></tr>
+          <tr><td>Gestión</td><td>Alta o vía operador (20-25%)</td><td>Baja</td></tr>
+          <tr><td>Desgaste</td><td>Mayor (rotación)</td><td>Menor</td></tr>
+          <tr><td>Gastos operativos</td><td>Limpieza, servicios, comisiones</td><td>Inquilino paga</td></tr>
+          <tr><td>ROI anual típico</td><td>8–16%</td><td>5–7%</td></tr>
+        </tbody>
+      </table>
+
+      <div class="warning">
+        <strong>Atención RNT:</strong> Toda propiedad de renta turística en Colombia debe estar inscrita en el Registro Nacional de Turismo (RNT) y declarar ante la DIAN. Cubrimos esto en el capítulo 4.
+      </div>
+
+
+      <h2>4. Impuestos inmobiliarios 2026</h2>
+      <p>Los impuestos a propiedades en Colombia se dividen en tres momentos:</p>
+
+      <h3>Al comprar (costos de cierre, ~3% del valor)</h3>
+      <ul>
+        <li><strong>Impuesto de beneficencia:</strong> 1% sobre el valor de la escritura.</li>
+        <li><strong>Impuesto de registro:</strong> 1% sobre el valor de la escritura.</li>
+        <li><strong>Gastos notariales:</strong> ~0.27% del valor.</li>
+        <li><strong>Honorarios legales:</strong> ~1% (recomendado tener abogado propio).</li>
+      </ul>
+
+      <h3>Mantener la propiedad (anual)</h3>
+      <p>El impuesto predial varía según estrato y avalúo catastral. En Cartagena en 2026:</p>
+      <table>
+        <thead><tr><th>Estrato</th><th>Tarifa anual aproximada</th></tr></thead>
+        <tbody>
+          <tr><td>1–2</td><td>0.4% – 0.6% del avalúo</td></tr>
+          <tr><td>3</td><td>0.6% – 0.8% del avalúo</td></tr>
+          <tr><td>4</td><td>0.9% – 1.1% del avalúo</td></tr>
+          <tr><td>5</td><td>1.1% – 1.4% del avalúo</td></tr>
+          <tr><td>6</td><td>1.4% – 1.6% del avalúo</td></tr>
+        </tbody>
+      </table>
+      <p><em>Tip:</em> pagar antes del 31 de marzo otorga descuento del 10% por pronto pago.</p>
+
+      <h3>Sobre los ingresos por arriendo</h3>
+      <ul>
+        <li><strong>Arriendo tradicional:</strong> los ingresos se suman a la renta líquida y tributan en cédula general (tarifas progresivas 0–39%). Retención en la fuente del 3.5% si el inquilino es persona jurídica.</li>
+        <li><strong>Renta turística (Airbnb):</strong> sujeto a IVA 19% y al INC (Impuesto al Consumo) cuando aplique. Plataformas como Airbnb retienen IVA en hospedajes desde 2024.</li>
+      </ul>
+
+      <h3>Al vender (ganancia ocasional)</h3>
+      <p>Si la propiedad fue tu activo durante <strong>≥ 2 años</strong>, la utilidad tributa al 15% como ganancia ocasional. Si es menos de 2 años, se considera renta líquida ordinaria (tarifa progresiva). Las primeras ~7,000 UVT (~$330M COP en 2026) de utilidad están exentas si era vivienda habitual.</p>
+
+      <div class="callout">
+        <strong>Para extranjeros:</strong> los no residentes tributan al 35% sobre el ingreso de fuente colombiana. Recomendamos siempre estructurar la inversión con un contador local para optimizar la carga.
+      </div>
+
+      <h2>5. Financiación: cómo pagar tu propiedad</h2>
+      <p>En 2026 hay cuatro vías principales para financiar tu inversión:</p>
+
+      <h3>5.1 Crédito hipotecario tradicional</h3>
+      <ul>
+        <li><strong>Cuota inicial:</strong> mínimo 30% del valor (no-VIS). 20% para vivienda VIS con subsidio.</li>
+        <li><strong>Plazo:</strong> hasta 30 años. Edad máxima al final: 70-75 años según banco.</li>
+        <li><strong>Tasa 2026:</strong> 9% – 14% efectivo anual según perfil. UVR ofrece tasa nominal menor pero ajustada por inflación.</li>
+        <li><strong>Bancos activos:</strong> Bancolombia, Davivienda, BBVA, Banco de Bogotá, AV Villas, Banco Caja Social.</li>
+      </ul>
+
+      <h3>5.2 Leasing habitacional</h3>
+      <p>Alternativa con cuota inicial desde 10-20%. La propiedad queda a nombre del banco hasta el último pago. Beneficio fiscal: la cuota es deducible al 100% como gasto. Tasa similar al crédito.</p>
+
+      <h3>5.3 Financiación con la constructora (sobre planos)</h3>
+      <p>En proyectos nuevos, la constructora suele permitir pagar el 30% durante la construcción (12-24 meses) y el 70% restante al recibir, por lo general financiado con un banco. Sin intereses durante la construcción es lo común.</p>
+
+      <h3>5.4 Para extranjeros: opciones</h3>
+      <ul>
+        <li><strong>Pago de contado:</strong> mayoría de inversionistas extranjeros. Transferencia internacional con "Formulario 4" (vital para repatriación posterior).</li>
+        <li><strong>Crédito en su país de origen:</strong> usar equity de una propiedad existente, suele ser más barato que un crédito colombiano.</li>
+        <li><strong>Crédito en bancos colombianos:</strong> raro pero posible si tienes residencia o ingresos demostrables en Colombia.</li>
+      </ul>
+
+      <div class="warning">
+        <strong>Ley 546 (1999):</strong> en Colombia está prohibido cobrar penalización por prepago en créditos hipotecarios para vivienda. Puedes hacer abonos a capital cuando quieras.
+      </div>
+
+
+      <h2>6. Due diligence: 20 verificaciones antes de firmar</h2>
+      <p>Antes de la promesa de compraventa, verifica obligatoriamente estos 20 puntos:</p>
+
+      <h3>Documentos del inmueble</h3>
+      <ol>
+        <li>Certificado de tradición y libertad (no mayor a 30 días).</li>
+        <li>Escritura pública de adquisición del vendedor.</li>
+        <li>Recibo de impuesto predial al día.</li>
+        <li>Recibo de servicios públicos al día (acueducto, luz, gas).</li>
+        <li>Paz y salvo de administración (si es propiedad horizontal).</li>
+        <li>Reglamento de propiedad horizontal (si aplica).</li>
+        <li>Manifestación de no tener procesos judiciales sobre el inmueble.</li>
+      </ol>
+
+      <h3>Verificación legal</h3>
+      <ol start="8">
+        <li>Estudio de títulos por abogado independiente (mínimo 20 años atrás).</li>
+        <li>Verificar afectaciones: hipotecas, embargos, servidumbres, patrimonio de familia.</li>
+        <li>Confirmar que el vendedor es el dueño real (cédula vs certificado).</li>
+        <li>Si hay hipoteca activa, plan claro de levantamiento al cierre.</li>
+        <li>Verificar uso del suelo en el POT de Cartagena (importante si reformarás).</li>
+      </ol>
+
+      <h3>Estado físico y técnico</h3>
+      <ol start="13">
+        <li>Inspección estructural (humedades, grietas, instalaciones eléctricas).</li>
+        <li>Verificar funcionamiento de A/C, plomería, electrodomésticos.</li>
+        <li>Inventario detallado si es amoblado (firmar lista anexa).</li>
+        <li>Verificar área real vs área en escritura.</li>
+        <li>Inspección de zonas comunes y estado del edificio.</li>
+      </ol>
+
+      <h3>Aspectos financieros</h3>
+      <ol start="18">
+        <li>Avalúo comercial independiente (no aceptes el del vendedor).</li>
+        <li>Verificar que el precio esté en línea con el mercado (comparables).</li>
+        <li>Calcular costos totales: precio + cierre + reformas + dotación = inversión real.</li>
+      </ol>
+
+      <h2>7. 10 errores que cuestan millones</h2>
+      <ol>
+        <li><strong>No hacer estudio de títulos.</strong> Comprar a alguien que no era el dueño real o con cargas ocultas. Costo: perder la propiedad o pagar por desembargarla.</li>
+        <li><strong>Confiar en el avalúo del vendedor.</strong> Siempre obtén un avalúo comercial independiente. Costo: pagar 20-40% más del valor real.</li>
+        <li><strong>No verificar el uso del suelo.</strong> Comprar pensando que harás Airbnb y descubrir que el régimen de propiedad horizontal lo prohíbe. Costo: ROI proyectado a la basura.</li>
+        <li><strong>No registrar el "Formulario 4" al transferir USD.</strong> Sin él, repatriar plusvalía es legalmente imposible. Costo: capital atrapado en COP.</li>
+        <li><strong>Comprar sobre planos sin reputación de la constructora.</strong> Quiebras, retrasos o calidad deficiente. Costo: años de pleitos y dinero perdido.</li>
+        <li><strong>Subestimar gastos operativos del Airbnb.</strong> Limpieza, comisiones (15-25%), mantenimiento, servicios, RNT, impuestos. El "ingreso bruto" Airbnb se reduce 30-40%. Costo: ROI real muy inferior a lo proyectado.</li>
+        <li><strong>No tener seguro.</strong> Daños, terremoto, responsabilidad civil. Costo: una emergencia te puede costar el equivalente a 1-2 años de renta.</li>
+        <li><strong>Dejarse llevar por la emoción de la vista.</strong> El "frente al mar" cuesta 30-40% más. Verifica que la prima sea justificable por ROI.</li>
+        <li><strong>No leer el reglamento de propiedad horizontal.</strong> Restricciones de Airbnb, mascotas, modificaciones. Costo: comprar y descubrir que no puedes hacer lo que querías.</li>
+        <li><strong>Firmar promesa sin verificar paz y salvo administrativo.</strong> Heredas las deudas. Costo: cuotas pendientes que pueden sumar millones.</li>
+      </ol>
+
+      <h2>8. Inversión desde el exterior</h2>
+      <p>Si no resides en Colombia, este es el flujo recomendado:</p>
+
+      <h3>Paso 1: Estructura legal</h3>
+      <p>Decide si comprarás como persona natural extranjera (más simple) o vía sociedad (mejor para múltiples propiedades / planificación fiscal).</p>
+
+      <h3>Paso 2: Poder notarial</h3>
+      <p>Otorga poder a un representante en Colombia (abogado o asesor de confianza). Debe ser firmado en consulado colombiano o apostillado en tu país.</p>
+
+      <h3>Paso 3: Transferencia de fondos</h3>
+      <p>Wire transfer desde tu banco al banco colombiano del vendedor. <strong>Crítico:</strong> el banco colombiano debe diligenciar el "Formulario 4" reportando la inversión extranjera al Banco de la República. Sin esto, repatriar capital o utilidades futuras es imposible legalmente.</p>
+
+      <h3>Paso 4: Escrituración</h3>
+      <p>Tu apoderado firma en notaría. Posteriormente se registra en la Oficina de Registro de Instrumentos Públicos. La escritura llega a tu nombre.</p>
+
+      <h3>Paso 5: Visa de inversionista (opcional)</h3>
+      <p>Si tu compra supera <strong>350 SMMLV (~USD 110.000 en 2026)</strong>, calificas para Visa Tipo M Inversionista: 3 años renovables, vía a residencia permanente y luego a la nacionalidad.</p>
+
+      <h3>Paso 6: Gestión y reportes</h3>
+      <p>Contrata administración profesional bilingüe (idealmente reportes mensuales en EN/ES con ingresos, gastos, ocupación). Declara renta anual ante DIAN.</p>
+
+      <h2>9. Anexo: calendario tributario 2026</h2>
+      <table>
+        <thead><tr><th>Fecha</th><th>Obligación</th></tr></thead>
+        <tbody>
+          <tr><td>31 marzo</td><td>Impuesto predial Cartagena (descuento 10% pronto pago)</td></tr>
+          <tr><td>30 junio</td><td>Impuesto predial sin descuento</td></tr>
+          <tr><td>Abril – julio</td><td>Declaración renta personas naturales (según último dígito de cédula)</td></tr>
+          <tr><td>Mensual</td><td>IVA renta turística (si aplica) — declaración bimestral</td></tr>
+          <tr><td>Bimestral</td><td>INC turismo si supera topes</td></tr>
+        </tbody>
+      </table>
+
+      <div class="callout">
+        <strong>Recomendación:</strong> contrata un contador especializado en inmobiliario por 4-8 millones COP/año. El ahorro fiscal y la tranquilidad valen 10x la inversión.
+      </div>
+
+      <h2>Conclusión</h2>
+      <p>Cartagena en 2026 sigue siendo uno de los mejores mercados de Latinoamérica para inversión inmobiliaria con dollar income, pero <strong>la diferencia entre un buen y un mal inversionista no está en la zona, sino en la rigurosidad del proceso</strong>: due diligence, estructura fiscal, gestión profesional y paciencia.</p>
+
+      <p>En Altorra acompañamos cada paso. Si esta guía te fue útil, agenda una sesión de diagnóstico gratuita y veamos juntos cuál es tu mejor próxima inversión.</p>
+
+      <p style="text-align:center;margin-top:32px"><strong>Altorra Inmobiliaria · Cartagena 2026</strong><br/><a href="https://altorrainmobiliaria.co" style="color:var(--gold)">altorrainmobiliaria.co</a> · WhatsApp +57 300 243 9810</p>
+    </div>
+
+    <!-- Final CTA -->
+    <div class="gi-cta">
+      <h2>¿Listo para dar el siguiente paso?</h2>
+      <p>Conversemos sobre tu caso específico. Asesoría inicial sin costo.</p>
+      <div style="display:flex;gap:12px;justify-content:center;flex-wrap:wrap">
+        <a class="btn btn-primary" href="contacto.html">Agendar asesoría</a>
+        <a class="btn" href="propiedades-comprar.html" style="border:2px solid var(--gold);color:var(--gold);background:#fff">Ver propiedades</a>
+        <a class="btn" href="https://wa.me/573002439810?text=Hola%20Altorra%2C%20le%C3%AD%20la%20Gu%C3%ADa%20del%20Inversionista%202026" target="_blank" rel="noopener" style="background:#25d366;color:#fff">WhatsApp</a>
+      </div>
+    </div>
+
+  </main>
+
+  <div id="footer-placeholder"></div>
+
+  <link rel="stylesheet" href="css/whatsapp-float.css"/>
+  <a href="https://wa.me/573002439810" class="whatsapp-float" target="_blank" rel="noopener" aria-label="Contactar por WhatsApp">
+    <svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path d="M16 0c-8.837 0-16 7.163-16 16 0 2.825.738 5.479 2.031 7.781l-2.031 7.219 7.375-1.938c2.238 1.213 4.8 1.938 7.531 1.938 8.838 0 16.094-7.163 16.094-16s-7.256-16-16-16zm9.563 22.188c-.394 1.113-1.95 2.038-3.194 2.313-.85.175-1.956.319-5.688-.919-4.769-1.581-7.844-6.356-8.081-6.65-.231-.294-1.95-2.594-1.95-4.95s1.238-3.513 1.675-3.994c.438-.481.956-.6 1.275-.6.319 0 .638.006.919.013.294.012.688-.113 1.075.819.394 1.025 1.35 3.294 1.469 3.531.119.238.2.519.038.819-.163.3-.244.488-.481.75-.238.263-.5.588-.713.788-.238.225-.488.469-.206.925.281.456 1.256 2.069 2.694 3.35 1.85 1.65 3.419 2.163 3.9 2.406.481.244.763.206 1.044-.125.281-.331 1.206-1.406 1.531-1.888.325-.481.644-.4 1.088-.238.444.163 2.819 1.331 3.3 1.569.481.238.8.356.919.556.119.2.119 1.144-.275 2.256z"/></svg>
+  </a>
+
+  <script src="js/firestore-meter.js" defer></script>
+  <script src="js/components.js" defer></script>
+  <script src="js/i18n.js"></script>
+  <script defer src="js/whatsapp-tracker.js"></script>
+  <script src="js/analytics.js" defer></script>
+  <script>
+    // Reveal content if user already submitted in a previous session
+    (function () {
+      try {
+        if (localStorage.getItem('altorra:guia-2026:unlocked') === '1') {
+          document.getElementById('contenido')?.classList.add('unlocked');
+        }
+      } catch (e) {}
+    })();
+
+    document.addEventListener('DOMContentLoaded', function () {
+      var form = document.getElementById('formGuia');
+      var btn = document.getElementById('btnGuia');
+      if (!form) return;
+      form.addEventListener('submit', async function (e) {
+        e.preventDefault();
+        btn.disabled = true;
+        btn.textContent = 'Enviando…';
+        var fd = new FormData(form);
+        try {
+          var mod = await import('https://www.gstatic.com/firebasejs/12.9.0/firebase-firestore.js');
+          await mod.addDoc(mod.collection(window.db, 'solicitudes'), {
+            nombre:    fd.get('nombre'),
+            email:     fd.get('email'),
+            telefono:  fd.get('telefono') || '',
+            tipo:      'descarga_guia_inversionista_2026',
+            origen:    'guia-inversionista-2026',
+            estado:    'pendiente',
+            createdAt: mod.serverTimestamp(),
+            datosExtra: {
+              interes:       fd.get('interes'),
+              recursoEnviado:'guia-inversionista-2026',
+            },
+            emailSent:    false,
+            requiereCita: false,
+          });
+          try { localStorage.setItem('altorra:guia-2026:unlocked', '1'); } catch (e) {}
+          var content = document.getElementById('contenido');
+          content?.classList.add('unlocked');
+          form.innerHTML = '<div style="text-align:center;padding:14px"><div style="font-size:2.4rem;margin-bottom:8px">✅</div><h3 style="color:var(--gold);margin:0 0 8px">¡Guía desbloqueada!</h3><p style="margin:0;color:var(--muted);font-size:.92rem">Te enviamos una copia a tu email. Continúa la lectura abajo.</p></div>';
+          if (content) {
+            setTimeout(function () { content.scrollIntoView({ behavior: 'smooth' }); }, 400);
+          }
+        } catch (err) {
+          console.error('Error:', err);
+          btn.disabled = false;
+          btn.textContent = 'Descargar guía gratis';
+          alert('Hubo un error. Intenta de nuevo o escríbenos por WhatsApp.');
+        }
+      });
+    });
+  </script>
+</body>
+</html>

--- a/invertir.html
+++ b/invertir.html
@@ -307,6 +307,9 @@
     <div class="hero-badge">📈 Guía de inversión 2026</div>
     <h1>Invertir en <span style="color:var(--gold)">Cartagena</span></h1>
     <p>Análisis de rentabilidad por zona, casos de éxito reales y oportunidades de inversión inmobiliaria en la Heroica.</p>
+    <div style="margin-top:24px">
+      <a href="guia-inversionista-2026.html" style="display:inline-block;background:linear-gradient(135deg,var(--gold),var(--accent));color:#000;padding:12px 24px;border-radius:99px;font-weight:800;text-decoration:none;font-size:.95rem">📘 Descarga la guía gratis</a>
+    </div>
   </div>
 
   <main id="main">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -13,6 +13,7 @@
   <url><loc>https://altorrainmobiliaria.co/renta-turistica.html</loc><lastmod>2026-04-25</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>
   <url><loc>https://altorrainmobiliaria.co/turismo-inmobiliario.html</loc><lastmod>2026-04-19</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
   <url><loc>https://altorrainmobiliaria.co/foreign-investors.html</loc><lastmod>2026-04-25</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://altorrainmobiliaria.co/guia-inversionista-2026.html</loc><lastmod>2026-04-25</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
   <url><loc>https://altorrainmobiliaria.co/simulador.html</loc><lastmod>2026-04-25</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://altorrainmobiliaria.co/avaluo.html</loc><lastmod>2026-04-19</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://altorrainmobiliaria.co/mapa.html</loc><lastmod>2026-04-19</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>


### PR DESCRIPTION
- New landing page guia-inversionista-2026.html (~5.500 words, 9 chapters): Cartagena market 2026, ROI by zone, Airbnb vs rental, taxes, financing, due diligence (20 checks), 10 costly errors, foreign investment, tax calendar.
- Email capture form writes to Firestore solicitudes with tipo='descarga_guia_inversionista_2026'.
- Content unlocks immediately after submit + persisted in localStorage.
- Print-styled CSS (@media print) hides chrome so users can save as PDF.
- Article JSON-LD schema for SEO.
- CTA links added in invertir.html, foreign-investors.html (EN) and footer.