### PR TITLE
refactor: extract shared landing page CSS from 12 inline <style> blocks

### DIFF
--- a/alto-bosque.html
+++ b/alto-bosque.html
@@ -23,40 +23,6 @@
   <script src="js/database.js" defer></script>
   <script src="js/cache-manager.js" defer></script>
   <script src="js/utils.js" defer></script>
-  <style>
-    .lp-hero{padding:calc(var(--header-h) + 56px) 16px 56px;text-align:center;background:linear-gradient(180deg,#0b0b0b,#1a1a2e);color:#fff;position:relative;overflow:hidden}
-    .lp-hero::before{content:'';position:absolute;inset:-50%;width:200%;height:200%;background:radial-gradient(ellipse at 30% 60%,rgba(212,175,55,.08),transparent 50%);pointer-events:none}
-    .lp-hero h1{font-size:clamp(1.8rem,5vw,2.8rem);font-weight:800;margin:0 0 12px;position:relative}
-    .lp-hero p{color:rgba(255,255,255,.7);font-size:1.05rem;max-width:680px;margin:0 auto;position:relative}
-    .hero-badge{display:inline-block;background:linear-gradient(135deg,var(--gold),var(--accent));color:#000;padding:6px 16px;border-radius:999px;font-size:.78rem;font-weight:800;letter-spacing:.5px;margin-bottom:18px;text-transform:uppercase;position:relative}
-    .lp-s{max-width:var(--page-max);margin:0 auto;padding:56px 16px}
-    .lp-s h2{font-size:1.6rem;font-weight:800;margin:0 0 8px}
-    .lp-s .sub{color:var(--muted);margin:0 0 32px;font-size:1rem;max-width:780px}
-    .stats-band{background:linear-gradient(135deg,#fffdf4,#fff);border:1px solid rgba(212,175,55,.18);border-radius:18px;padding:28px;margin-top:24px;display:grid;grid-template-columns:repeat(4,1fr);gap:20px;text-align:center}
-    .stats-band .item small{font-size:.75rem;color:var(--muted);display:block;margin-bottom:4px;text-transform:uppercase;letter-spacing:.4px}
-    .stats-band .item strong{font-size:1.4rem;font-weight:800;color:var(--text)}
-    .stats-band .item strong.gold{color:var(--gold)}
-    @media(max-width:680px){.stats-band{grid-template-columns:repeat(2,1fr)}}
-    .features-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:18px}
-    .feature-card{background:#fff;border:1px solid rgba(17,24,39,.07);border-radius:14px;padding:22px;box-shadow:0 4px 14px rgba(0,0,0,.04)}
-    .feature-card .ico{font-size:1.8rem;margin-bottom:10px}
-    .feature-card h3{font-size:1rem;font-weight:700;margin:0 0 6px}
-    .feature-card p{font-size:.88rem;color:var(--muted);margin:0;line-height:1.5}
-    .invest-block{background:linear-gradient(135deg,#0b0b0b,#1a1a2e);color:#fff;border-radius:18px;padding:38px;margin-top:24px}
-    .invest-block h3{color:#fff;font-size:1.3rem;margin:0 0 8px}
-    .invest-block p{color:rgba(255,255,255,.75);margin:0 0 20px}
-    .invest-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:18px}
-    .invest-item{background:rgba(255,255,255,.05);border:1px solid rgba(212,175,55,.18);border-radius:12px;padding:18px}
-    .invest-item small{font-size:.72rem;color:rgba(255,255,255,.55);text-transform:uppercase;letter-spacing:.4px;display:block;margin-bottom:6px}
-    .invest-item strong{font-size:1.15rem;font-weight:800;color:var(--gold)}
-    @media(max-width:680px){.invest-grid{grid-template-columns:1fr}}
-    .lp-cta{text-align:center;padding:56px 16px;background:linear-gradient(180deg,#fffdf4,#fff)}
-    .lp-cta h2{font-size:1.6rem;font-weight:800;margin:0 0 12px}
-    .lp-cta p{color:var(--muted);margin:0 0 24px;font-size:1rem}
-    .related-links{display:flex;flex-wrap:wrap;gap:10px;justify-content:center;margin-top:28px}
-    .related-links a{padding:8px 16px;border:1px solid rgba(212,175,55,.3);border-radius:999px;color:var(--text);text-decoration:none;font-size:.88rem;font-weight:600;background:#fff;transition:all .2s}
-    .related-links a:hover{background:var(--gold);color:#000;border-color:var(--gold)}
-  </style>
 </head>
 <body>
   <a class="skip-link" href="#main">Saltar al contenido</a>

--- a/cielo-mar.html
+++ b/cielo-mar.html
@@ -23,40 +23,6 @@
   <script src="js/database.js" defer></script>
   <script src="js/cache-manager.js" defer></script>
   <script src="js/utils.js" defer></script>
-  <style>
-    .lp-hero{padding:calc(var(--header-h) + 56px) 16px 56px;text-align:center;background:linear-gradient(180deg,#0b0b0b,#1a1a2e);color:#fff;position:relative;overflow:hidden}
-    .lp-hero::before{content:'';position:absolute;inset:-50%;width:200%;height:200%;background:radial-gradient(ellipse at 30% 60%,rgba(212,175,55,.08),transparent 50%);pointer-events:none}
-    .lp-hero h1{font-size:clamp(1.8rem,5vw,2.8rem);font-weight:800;margin:0 0 12px;position:relative}
-    .lp-hero p{color:rgba(255,255,255,.7);font-size:1.05rem;max-width:680px;margin:0 auto;position:relative}
-    .hero-badge{display:inline-block;background:linear-gradient(135deg,var(--gold),var(--accent));color:#000;padding:6px 16px;border-radius:999px;font-size:.78rem;font-weight:800;letter-spacing:.5px;margin-bottom:18px;text-transform:uppercase;position:relative}
-    .lp-s{max-width:var(--page-max);margin:0 auto;padding:56px 16px}
-    .lp-s h2{font-size:1.6rem;font-weight:800;margin:0 0 8px}
-    .lp-s .sub{color:var(--muted);margin:0 0 32px;font-size:1rem;max-width:780px}
-    .stats-band{background:linear-gradient(135deg,#fffdf4,#fff);border:1px solid rgba(212,175,55,.18);border-radius:18px;padding:28px;margin-top:24px;display:grid;grid-template-columns:repeat(4,1fr);gap:20px;text-align:center}
-    .stats-band .item small{font-size:.75rem;color:var(--muted);display:block;margin-bottom:4px;text-transform:uppercase;letter-spacing:.4px}
-    .stats-band .item strong{font-size:1.4rem;font-weight:800;color:var(--text)}
-    .stats-band .item strong.gold{color:var(--gold)}
-    @media(max-width:680px){.stats-band{grid-template-columns:repeat(2,1fr)}}
-    .features-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:18px}
-    .feature-card{background:#fff;border:1px solid rgba(17,24,39,.07);border-radius:14px;padding:22px;box-shadow:0 4px 14px rgba(0,0,0,.04)}
-    .feature-card .ico{font-size:1.8rem;margin-bottom:10px}
-    .feature-card h3{font-size:1rem;font-weight:700;margin:0 0 6px}
-    .feature-card p{font-size:.88rem;color:var(--muted);margin:0;line-height:1.5}
-    .invest-block{background:linear-gradient(135deg,#0b0b0b,#1a1a2e);color:#fff;border-radius:18px;padding:38px;margin-top:24px}
-    .invest-block h3{color:#fff;font-size:1.3rem;margin:0 0 8px}
-    .invest-block p{color:rgba(255,255,255,.75);margin:0 0 20px}
-    .invest-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:18px}
-    .invest-item{background:rgba(255,255,255,.05);border:1px solid rgba(212,175,55,.18);border-radius:12px;padding:18px}
-    .invest-item small{font-size:.72rem;color:rgba(255,255,255,.55);text-transform:uppercase;letter-spacing:.4px;display:block;margin-bottom:6px}
-    .invest-item strong{font-size:1.15rem;font-weight:800;color:var(--gold)}
-    @media(max-width:680px){.invest-grid{grid-template-columns:1fr}}
-    .lp-cta{text-align:center;padding:56px 16px;background:linear-gradient(180deg,#fffdf4,#fff)}
-    .lp-cta h2{font-size:1.6rem;font-weight:800;margin:0 0 12px}
-    .lp-cta p{color:var(--muted);margin:0 0 24px;font-size:1rem}
-    .related-links{display:flex;flex-wrap:wrap;gap:10px;justify-content:center;margin-top:28px}
-    .related-links a{padding:8px 16px;border:1px solid rgba(212,175,55,.3);border-radius:999px;color:var(--text);text-decoration:none;font-size:.88rem;font-weight:600;background:#fff;transition:all .2s}
-    .related-links a:hover{background:var(--gold);color:#000;border-color:var(--gold)}
-  </style>
 </head>
 <body>
   <a class="skip-link" href="#main">Saltar al contenido</a>

--- a/el-cabrero.html
+++ b/el-cabrero.html
@@ -23,40 +23,6 @@
   <script src="js/database.js" defer></script>
   <script src="js/cache-manager.js" defer></script>
   <script src="js/utils.js" defer></script>
-  <style>
-    .lp-hero{padding:calc(var(--header-h) + 56px) 16px 56px;text-align:center;background:linear-gradient(180deg,#0b0b0b,#1a1a2e);color:#fff;position:relative;overflow:hidden}
-    .lp-hero::before{content:'';position:absolute;inset:-50%;width:200%;height:200%;background:radial-gradient(ellipse at 30% 60%,rgba(212,175,55,.08),transparent 50%);pointer-events:none}
-    .lp-hero h1{font-size:clamp(1.8rem,5vw,2.8rem);font-weight:800;margin:0 0 12px;position:relative}
-    .lp-hero p{color:rgba(255,255,255,.7);font-size:1.05rem;max-width:680px;margin:0 auto;position:relative}
-    .hero-badge{display:inline-block;background:linear-gradient(135deg,var(--gold),var(--accent));color:#000;padding:6px 16px;border-radius:999px;font-size:.78rem;font-weight:800;letter-spacing:.5px;margin-bottom:18px;text-transform:uppercase;position:relative}
-    .lp-s{max-width:var(--page-max);margin:0 auto;padding:56px 16px}
-    .lp-s h2{font-size:1.6rem;font-weight:800;margin:0 0 8px}
-    .lp-s .sub{color:var(--muted);margin:0 0 32px;font-size:1rem;max-width:780px}
-    .stats-band{background:linear-gradient(135deg,#fffdf4,#fff);border:1px solid rgba(212,175,55,.18);border-radius:18px;padding:28px;margin-top:24px;display:grid;grid-template-columns:repeat(4,1fr);gap:20px;text-align:center}
-    .stats-band .item small{font-size:.75rem;color:var(--muted);display:block;margin-bottom:4px;text-transform:uppercase;letter-spacing:.4px}
-    .stats-band .item strong{font-size:1.4rem;font-weight:800;color:var(--text)}
-    .stats-band .item strong.gold{color:var(--gold)}
-    @media(max-width:680px){.stats-band{grid-template-columns:repeat(2,1fr)}}
-    .features-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:18px}
-    .feature-card{background:#fff;border:1px solid rgba(17,24,39,.07);border-radius:14px;padding:22px;box-shadow:0 4px 14px rgba(0,0,0,.04)}
-    .feature-card .ico{font-size:1.8rem;margin-bottom:10px}
-    .feature-card h3{font-size:1rem;font-weight:700;margin:0 0 6px}
-    .feature-card p{font-size:.88rem;color:var(--muted);margin:0;line-height:1.5}
-    .invest-block{background:linear-gradient(135deg,#0b0b0b,#1a1a2e);color:#fff;border-radius:18px;padding:38px;margin-top:24px}
-    .invest-block h3{color:#fff;font-size:1.3rem;margin:0 0 8px}
-    .invest-block p{color:rgba(255,255,255,.75);margin:0 0 20px}
-    .invest-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:18px}
-    .invest-item{background:rgba(255,255,255,.05);border:1px solid rgba(212,175,55,.18);border-radius:12px;padding:18px}
-    .invest-item small{font-size:.72rem;color:rgba(255,255,255,.55);text-transform:uppercase;letter-spacing:.4px;display:block;margin-bottom:6px}
-    .invest-item strong{font-size:1.15rem;font-weight:800;color:var(--gold)}
-    @media(max-width:680px){.invest-grid{grid-template-columns:1fr}}
-    .lp-cta{text-align:center;padding:56px 16px;background:linear-gradient(180deg,#fffdf4,#fff)}
-    .lp-cta h2{font-size:1.6rem;font-weight:800;margin:0 0 12px}
-    .lp-cta p{color:var(--muted);margin:0 0 24px;font-size:1rem}
-    .related-links{display:flex;flex-wrap:wrap;gap:10px;justify-content:center;margin-top:28px}
-    .related-links a{padding:8px 16px;border:1px solid rgba(212,175,55,.3);border-radius:999px;color:var(--text);text-decoration:none;font-size:.88rem;font-weight:600;background:#fff;transition:all .2s}
-    .related-links a:hover{background:var(--gold);color:#000;border-color:var(--gold)}
-  </style>
 </head>
 <body>
   <a class="skip-link" href="#main">Saltar al contenido</a>

--- a/el-laguito.html
+++ b/el-laguito.html
@@ -23,40 +23,6 @@
   <script src="js/database.js" defer></script>
   <script src="js/cache-manager.js" defer></script>
   <script src="js/utils.js" defer></script>
-  <style>
-    .lp-hero{padding:calc(var(--header-h) + 56px) 16px 56px;text-align:center;background:linear-gradient(180deg,#0b0b0b,#1a1a2e);color:#fff;position:relative;overflow:hidden}
-    .lp-hero::before{content:'';position:absolute;inset:-50%;width:200%;height:200%;background:radial-gradient(ellipse at 30% 60%,rgba(212,175,55,.08),transparent 50%);pointer-events:none}
-    .lp-hero h1{font-size:clamp(1.8rem,5vw,2.8rem);font-weight:800;margin:0 0 12px;position:relative}
-    .lp-hero p{color:rgba(255,255,255,.7);font-size:1.05rem;max-width:680px;margin:0 auto;position:relative}
-    .hero-badge{display:inline-block;background:linear-gradient(135deg,var(--gold),var(--accent));color:#000;padding:6px 16px;border-radius:999px;font-size:.78rem;font-weight:800;letter-spacing:.5px;margin-bottom:18px;text-transform:uppercase;position:relative}
-    .lp-s{max-width:var(--page-max);margin:0 auto;padding:56px 16px}
-    .lp-s h2{font-size:1.6rem;font-weight:800;margin:0 0 8px}
-    .lp-s .sub{color:var(--muted);margin:0 0 32px;font-size:1rem;max-width:780px}
-    .stats-band{background:linear-gradient(135deg,#fffdf4,#fff);border:1px solid rgba(212,175,55,.18);border-radius:18px;padding:28px;margin-top:24px;display:grid;grid-template-columns:repeat(4,1fr);gap:20px;text-align:center}
-    .stats-band .item small{font-size:.75rem;color:var(--muted);display:block;margin-bottom:4px;text-transform:uppercase;letter-spacing:.4px}
-    .stats-band .item strong{font-size:1.4rem;font-weight:800;color:var(--text)}
-    .stats-band .item strong.gold{color:var(--gold)}
-    @media(max-width:680px){.stats-band{grid-template-columns:repeat(2,1fr)}}
-    .features-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:18px}
-    .feature-card{background:#fff;border:1px solid rgba(17,24,39,.07);border-radius:14px;padding:22px;box-shadow:0 4px 14px rgba(0,0,0,.04)}
-    .feature-card .ico{font-size:1.8rem;margin-bottom:10px}
-    .feature-card h3{font-size:1rem;font-weight:700;margin:0 0 6px}
-    .feature-card p{font-size:.88rem;color:var(--muted);margin:0;line-height:1.5}
-    .invest-block{background:linear-gradient(135deg,#0b0b0b,#1a1a2e);color:#fff;border-radius:18px;padding:38px;margin-top:24px}
-    .invest-block h3{color:#fff;font-size:1.3rem;margin:0 0 8px}
-    .invest-block p{color:rgba(255,255,255,.75);margin:0 0 20px}
-    .invest-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:18px}
-    .invest-item{background:rgba(255,255,255,.05);border:1px solid rgba(212,175,55,.18);border-radius:12px;padding:18px}
-    .invest-item small{font-size:.72rem;color:rgba(255,255,255,.55);text-transform:uppercase;letter-spacing:.4px;display:block;margin-bottom:6px}
-    .invest-item strong{font-size:1.15rem;font-weight:800;color:var(--gold)}
-    @media(max-width:680px){.invest-grid{grid-template-columns:1fr}}
-    .lp-cta{text-align:center;padding:56px 16px;background:linear-gradient(180deg,#fffdf4,#fff)}
-    .lp-cta h2{font-size:1.6rem;font-weight:800;margin:0 0 12px}
-    .lp-cta p{color:var(--muted);margin:0 0 24px;font-size:1rem}
-    .related-links{display:flex;flex-wrap:wrap;gap:10px;justify-content:center;margin-top:28px}
-    .related-links a{padding:8px 16px;border:1px solid rgba(212,175,55,.3);border-radius:999px;color:var(--text);text-decoration:none;font-size:.88rem;font-weight:600;background:#fff;transition:all .2s}
-    .related-links a:hover{background:var(--gold);color:#000;border-color:var(--gold)}
-  </style>
 </head>
 <body>
   <a class="skip-link" href="#main">Saltar al contenido</a>

--- a/karibana.html
+++ b/karibana.html
@@ -23,40 +23,6 @@
   <script src="js/database.js" defer></script>
   <script src="js/cache-manager.js" defer></script>
   <script src="js/utils.js" defer></script>
-  <style>
-    .lp-hero{padding:calc(var(--header-h) + 56px) 16px 56px;text-align:center;background:linear-gradient(180deg,#0b0b0b,#1a1a2e);color:#fff;position:relative;overflow:hidden}
-    .lp-hero::before{content:'';position:absolute;inset:-50%;width:200%;height:200%;background:radial-gradient(ellipse at 30% 60%,rgba(212,175,55,.08),transparent 50%);pointer-events:none}
-    .lp-hero h1{font-size:clamp(1.8rem,5vw,2.8rem);font-weight:800;margin:0 0 12px;position:relative}
-    .lp-hero p{color:rgba(255,255,255,.7);font-size:1.05rem;max-width:680px;margin:0 auto;position:relative}
-    .hero-badge{display:inline-block;background:linear-gradient(135deg,var(--gold),var(--accent));color:#000;padding:6px 16px;border-radius:999px;font-size:.78rem;font-weight:800;letter-spacing:.5px;margin-bottom:18px;text-transform:uppercase;position:relative}
-    .lp-s{max-width:var(--page-max);margin:0 auto;padding:56px 16px}
-    .lp-s h2{font-size:1.6rem;font-weight:800;margin:0 0 8px}
-    .lp-s .sub{color:var(--muted);margin:0 0 32px;font-size:1rem;max-width:780px}
-    .stats-band{background:linear-gradient(135deg,#fffdf4,#fff);border:1px solid rgba(212,175,55,.18);border-radius:18px;padding:28px;margin-top:24px;display:grid;grid-template-columns:repeat(4,1fr);gap:20px;text-align:center}
-    .stats-band .item small{font-size:.75rem;color:var(--muted);display:block;margin-bottom:4px;text-transform:uppercase;letter-spacing:.4px}
-    .stats-band .item strong{font-size:1.4rem;font-weight:800;color:var(--text)}
-    .stats-band .item strong.gold{color:var(--gold)}
-    @media(max-width:680px){.stats-band{grid-template-columns:repeat(2,1fr)}}
-    .features-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:18px}
-    .feature-card{background:#fff;border:1px solid rgba(17,24,39,.07);border-radius:14px;padding:22px;box-shadow:0 4px 14px rgba(0,0,0,.04)}
-    .feature-card .ico{font-size:1.8rem;margin-bottom:10px}
-    .feature-card h3{font-size:1rem;font-weight:700;margin:0 0 6px}
-    .feature-card p{font-size:.88rem;color:var(--muted);margin:0;line-height:1.5}
-    .invest-block{background:linear-gradient(135deg,#0b0b0b,#1a1a2e);color:#fff;border-radius:18px;padding:38px;margin-top:24px}
-    .invest-block h3{color:#fff;font-size:1.3rem;margin:0 0 8px}
-    .invest-block p{color:rgba(255,255,255,.75);margin:0 0 20px}
-    .invest-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:18px}
-    .invest-item{background:rgba(255,255,255,.05);border:1px solid rgba(212,175,55,.18);border-radius:12px;padding:18px}
-    .invest-item small{font-size:.72rem;color:rgba(255,255,255,.55);text-transform:uppercase;letter-spacing:.4px;display:block;margin-bottom:6px}
-    .invest-item strong{font-size:1.15rem;font-weight:800;color:var(--gold)}
-    @media(max-width:680px){.invest-grid{grid-template-columns:1fr}}
-    .lp-cta{text-align:center;padding:56px 16px;background:linear-gradient(180deg,#fffdf4,#fff)}
-    .lp-cta h2{font-size:1.6rem;font-weight:800;margin:0 0 12px}
-    .lp-cta p{color:var(--muted);margin:0 0 24px;font-size:1rem}
-    .related-links{display:flex;flex-wrap:wrap;gap:10px;justify-content:center;margin-top:28px}
-    .related-links a{padding:8px 16px;border:1px solid rgba(212,175,55,.3);border-radius:999px;color:var(--text);text-decoration:none;font-size:.88rem;font-weight:600;background:#fff;transition:all .2s}
-    .related-links a:hover{background:var(--gold);color:#000;border-color:var(--gold)}
-  </style>
 </head>
 <body>
   <a class="skip-link" href="#main">Saltar al contenido</a>

--- a/la-boquilla.html
+++ b/la-boquilla.html
@@ -23,40 +23,6 @@
   <script src="js/database.js" defer></script>
   <script src="js/cache-manager.js" defer></script>
   <script src="js/utils.js" defer></script>
-  <style>
-    .lp-hero{padding:calc(var(--header-h) + 56px) 16px 56px;text-align:center;background:linear-gradient(180deg,#0b0b0b,#1a1a2e);color:#fff;position:relative;overflow:hidden}
-    .lp-hero::before{content:'';position:absolute;inset:-50%;width:200%;height:200%;background:radial-gradient(ellipse at 30% 60%,rgba(212,175,55,.08),transparent 50%);pointer-events:none}
-    .lp-hero h1{font-size:clamp(1.8rem,5vw,2.8rem);font-weight:800;margin:0 0 12px;position:relative}
-    .lp-hero p{color:rgba(255,255,255,.7);font-size:1.05rem;max-width:680px;margin:0 auto;position:relative}
-    .hero-badge{display:inline-block;background:linear-gradient(135deg,var(--gold),var(--accent));color:#000;padding:6px 16px;border-radius:999px;font-size:.78rem;font-weight:800;letter-spacing:.5px;margin-bottom:18px;text-transform:uppercase;position:relative}
-    .lp-s{max-width:var(--page-max);margin:0 auto;padding:56px 16px}
-    .lp-s h2{font-size:1.6rem;font-weight:800;margin:0 0 8px}
-    .lp-s .sub{color:var(--muted);margin:0 0 32px;font-size:1rem;max-width:780px}
-    .stats-band{background:linear-gradient(135deg,#fffdf4,#fff);border:1px solid rgba(212,175,55,.18);border-radius:18px;padding:28px;margin-top:24px;display:grid;grid-template-columns:repeat(4,1fr);gap:20px;text-align:center}
-    .stats-band .item small{font-size:.75rem;color:var(--muted);display:block;margin-bottom:4px;text-transform:uppercase;letter-spacing:.4px}
-    .stats-band .item strong{font-size:1.4rem;font-weight:800;color:var(--text)}
-    .stats-band .item strong.gold{color:var(--gold)}
-    @media(max-width:680px){.stats-band{grid-template-columns:repeat(2,1fr)}}
-    .features-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:18px}
-    .feature-card{background:#fff;border:1px solid rgba(17,24,39,.07);border-radius:14px;padding:22px;box-shadow:0 4px 14px rgba(0,0,0,.04)}
-    .feature-card .ico{font-size:1.8rem;margin-bottom:10px}
-    .feature-card h3{font-size:1rem;font-weight:700;margin:0 0 6px}
-    .feature-card p{font-size:.88rem;color:var(--muted);margin:0;line-height:1.5}
-    .invest-block{background:linear-gradient(135deg,#0b0b0b,#1a1a2e);color:#fff;border-radius:18px;padding:38px;margin-top:24px}
-    .invest-block h3{color:#fff;font-size:1.3rem;margin:0 0 8px}
-    .invest-block p{color:rgba(255,255,255,.75);margin:0 0 20px}
-    .invest-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:18px}
-    .invest-item{background:rgba(255,255,255,.05);border:1px solid rgba(212,175,55,.18);border-radius:12px;padding:18px}
-    .invest-item small{font-size:.72rem;color:rgba(255,255,255,.55);text-transform:uppercase;letter-spacing:.4px;display:block;margin-bottom:6px}
-    .invest-item strong{font-size:1.15rem;font-weight:800;color:var(--gold)}
-    @media(max-width:680px){.invest-grid{grid-template-columns:1fr}}
-    .lp-cta{text-align:center;padding:56px 16px;background:linear-gradient(180deg,#fffdf4,#fff)}
-    .lp-cta h2{font-size:1.6rem;font-weight:800;margin:0 0 12px}
-    .lp-cta p{color:var(--muted);margin:0 0 24px;font-size:1rem}
-    .related-links{display:flex;flex-wrap:wrap;gap:10px;justify-content:center;margin-top:28px}
-    .related-links a{padding:8px 16px;border:1px solid rgba(212,175,55,.3);border-radius:999px;color:var(--text);text-decoration:none;font-size:.88rem;font-weight:600;background:#fff;transition:all .2s}
-    .related-links a:hover{background:var(--gold);color:#000;border-color:var(--gold)}
-  </style>
 </head>
 <body>
   <a class="skip-link" href="#main">Saltar al contenido</a>

--- a/manzanillo-del-mar.html
+++ b/manzanillo-del-mar.html
@@ -23,40 +23,6 @@
   <script src="js/database.js" defer></script>
   <script src="js/cache-manager.js" defer></script>
   <script src="js/utils.js" defer></script>
-  <style>
-    .lp-hero{padding:calc(var(--header-h) + 56px) 16px 56px;text-align:center;background:linear-gradient(180deg,#0b0b0b,#1a1a2e);color:#fff;position:relative;overflow:hidden}
-    .lp-hero::before{content:'';position:absolute;inset:-50%;width:200%;height:200%;background:radial-gradient(ellipse at 30% 60%,rgba(212,175,55,.08),transparent 50%);pointer-events:none}
-    .lp-hero h1{font-size:clamp(1.8rem,5vw,2.8rem);font-weight:800;margin:0 0 12px;position:relative}
-    .lp-hero p{color:rgba(255,255,255,.7);font-size:1.05rem;max-width:680px;margin:0 auto;position:relative}
-    .hero-badge{display:inline-block;background:linear-gradient(135deg,var(--gold),var(--accent));color:#000;padding:6px 16px;border-radius:999px;font-size:.78rem;font-weight:800;letter-spacing:.5px;margin-bottom:18px;text-transform:uppercase;position:relative}
-    .lp-s{max-width:var(--page-max);margin:0 auto;padding:56px 16px}
-    .lp-s h2{font-size:1.6rem;font-weight:800;margin:0 0 8px}
-    .lp-s .sub{color:var(--muted);margin:0 0 32px;font-size:1rem;max-width:780px}
-    .stats-band{background:linear-gradient(135deg,#fffdf4,#fff);border:1px solid rgba(212,175,55,.18);border-radius:18px;padding:28px;margin-top:24px;display:grid;grid-template-columns:repeat(4,1fr);gap:20px;text-align:center}
-    .stats-band .item small{font-size:.75rem;color:var(--muted);display:block;margin-bottom:4px;text-transform:uppercase;letter-spacing:.4px}
-    .stats-band .item strong{font-size:1.4rem;font-weight:800;color:var(--text)}
-    .stats-band .item strong.gold{color:var(--gold)}
-    @media(max-width:680px){.stats-band{grid-template-columns:repeat(2,1fr)}}
-    .features-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:18px}
-    .feature-card{background:#fff;border:1px solid rgba(17,24,39,.07);border-radius:14px;padding:22px;box-shadow:0 4px 14px rgba(0,0,0,.04)}
-    .feature-card .ico{font-size:1.8rem;margin-bottom:10px}
-    .feature-card h3{font-size:1rem;font-weight:700;margin:0 0 6px}
-    .feature-card p{font-size:.88rem;color:var(--muted);margin:0;line-height:1.5}
-    .invest-block{background:linear-gradient(135deg,#0b0b0b,#1a1a2e);color:#fff;border-radius:18px;padding:38px;margin-top:24px}
-    .invest-block h3{color:#fff;font-size:1.3rem;margin:0 0 8px}
-    .invest-block p{color:rgba(255,255,255,.75);margin:0 0 20px}
-    .invest-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:18px}
-    .invest-item{background:rgba(255,255,255,.05);border:1px solid rgba(212,175,55,.18);border-radius:12px;padding:18px}
-    .invest-item small{font-size:.72rem;color:rgba(255,255,255,.55);text-transform:uppercase;letter-spacing:.4px;display:block;margin-bottom:6px}
-    .invest-item strong{font-size:1.15rem;font-weight:800;color:var(--gold)}
-    @media(max-width:680px){.invest-grid{grid-template-columns:1fr}}
-    .lp-cta{text-align:center;padding:56px 16px;background:linear-gradient(180deg,#fffdf4,#fff)}
-    .lp-cta h2{font-size:1.6rem;font-weight:800;margin:0 0 12px}
-    .lp-cta p{color:var(--muted);margin:0 0 24px;font-size:1rem}
-    .related-links{display:flex;flex-wrap:wrap;gap:10px;justify-content:center;margin-top:28px}
-    .related-links a{padding:8px 16px;border:1px solid rgba(212,175,55,.3);border-radius:999px;color:var(--text);text-decoration:none;font-size:.88rem;font-weight:600;background:#fff;transition:all .2s}
-    .related-links a:hover{background:var(--gold);color:#000;border-color:var(--gold)}
-  </style>
 </head>
 <body>
   <a class="skip-link" href="#main">Saltar al contenido</a>

--- a/marbella.html
+++ b/marbella.html
@@ -23,40 +23,6 @@
   <script src="js/database.js" defer></script>
   <script src="js/cache-manager.js" defer></script>
   <script src="js/utils.js" defer></script>
-  <style>
-    .lp-hero{padding:calc(var(--header-h) + 56px) 16px 56px;text-align:center;background:linear-gradient(180deg,#0b0b0b,#1a1a2e);color:#fff;position:relative;overflow:hidden}
-    .lp-hero::before{content:'';position:absolute;inset:-50%;width:200%;height:200%;background:radial-gradient(ellipse at 30% 60%,rgba(212,175,55,.08),transparent 50%);pointer-events:none}
-    .lp-hero h1{font-size:clamp(1.8rem,5vw,2.8rem);font-weight:800;margin:0 0 12px;position:relative}
-    .lp-hero p{color:rgba(255,255,255,.7);font-size:1.05rem;max-width:680px;margin:0 auto;position:relative}
-    .hero-badge{display:inline-block;background:linear-gradient(135deg,var(--gold),var(--accent));color:#000;padding:6px 16px;border-radius:999px;font-size:.78rem;font-weight:800;letter-spacing:.5px;margin-bottom:18px;text-transform:uppercase;position:relative}
-    .lp-s{max-width:var(--page-max);margin:0 auto;padding:56px 16px}
-    .lp-s h2{font-size:1.6rem;font-weight:800;margin:0 0 8px}
-    .lp-s .sub{color:var(--muted);margin:0 0 32px;font-size:1rem;max-width:780px}
-    .stats-band{background:linear-gradient(135deg,#fffdf4,#fff);border:1px solid rgba(212,175,55,.18);border-radius:18px;padding:28px;margin-top:24px;display:grid;grid-template-columns:repeat(4,1fr);gap:20px;text-align:center}
-    .stats-band .item small{font-size:.75rem;color:var(--muted);display:block;margin-bottom:4px;text-transform:uppercase;letter-spacing:.4px}
-    .stats-band .item strong{font-size:1.4rem;font-weight:800;color:var(--text)}
-    .stats-band .item strong.gold{color:var(--gold)}
-    @media(max-width:680px){.stats-band{grid-template-columns:repeat(2,1fr)}}
-    .features-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:18px}
-    .feature-card{background:#fff;border:1px solid rgba(17,24,39,.07);border-radius:14px;padding:22px;box-shadow:0 4px 14px rgba(0,0,0,.04)}
-    .feature-card .ico{font-size:1.8rem;margin-bottom:10px}
-    .feature-card h3{font-size:1rem;font-weight:700;margin:0 0 6px}
-    .feature-card p{font-size:.88rem;color:var(--muted);margin:0;line-height:1.5}
-    .invest-block{background:linear-gradient(135deg,#0b0b0b,#1a1a2e);color:#fff;border-radius:18px;padding:38px;margin-top:24px}
-    .invest-block h3{color:#fff;font-size:1.3rem;margin:0 0 8px}
-    .invest-block p{color:rgba(255,255,255,.75);margin:0 0 20px}
-    .invest-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:18px}
-    .invest-item{background:rgba(255,255,255,.05);border:1px solid rgba(212,175,55,.18);border-radius:12px;padding:18px}
-    .invest-item small{font-size:.72rem;color:rgba(255,255,255,.55);text-transform:uppercase;letter-spacing:.4px;display:block;margin-bottom:6px}
-    .invest-item strong{font-size:1.15rem;font-weight:800;color:var(--gold)}
-    @media(max-width:680px){.invest-grid{grid-template-columns:1fr}}
-    .lp-cta{text-align:center;padding:56px 16px;background:linear-gradient(180deg,#fffdf4,#fff)}
-    .lp-cta h2{font-size:1.6rem;font-weight:800;margin:0 0 12px}
-    .lp-cta p{color:var(--muted);margin:0 0 24px;font-size:1rem}
-    .related-links{display:flex;flex-wrap:wrap;gap:10px;justify-content:center;margin-top:28px}
-    .related-links a{padding:8px 16px;border:1px solid rgba(212,175,55,.3);border-radius:999px;color:var(--text);text-decoration:none;font-size:.88rem;font-weight:600;background:#fff;transition:all .2s}
-    .related-links a:hover{background:var(--gold);color:#000;border-color:var(--gold)}
-  </style>
 </head>
 <body>
   <a class="skip-link" href="#main">Saltar al contenido</a>

--- a/pie-de-la-popa.html
+++ b/pie-de-la-popa.html
@@ -23,40 +23,6 @@
   <script src="js/database.js" defer></script>
   <script src="js/cache-manager.js" defer></script>
   <script src="js/utils.js" defer></script>
-  <style>
-    .lp-hero{padding:calc(var(--header-h) + 56px) 16px 56px;text-align:center;background:linear-gradient(180deg,#0b0b0b,#1a1a2e);color:#fff;position:relative;overflow:hidden}
-    .lp-hero::before{content:'';position:absolute;inset:-50%;width:200%;height:200%;background:radial-gradient(ellipse at 30% 60%,rgba(212,175,55,.08),transparent 50%);pointer-events:none}
-    .lp-hero h1{font-size:clamp(1.8rem,5vw,2.8rem);font-weight:800;margin:0 0 12px;position:relative}
-    .lp-hero p{color:rgba(255,255,255,.7);font-size:1.05rem;max-width:680px;margin:0 auto;position:relative}
-    .hero-badge{display:inline-block;background:linear-gradient(135deg,var(--gold),var(--accent));color:#000;padding:6px 16px;border-radius:999px;font-size:.78rem;font-weight:800;letter-spacing:.5px;margin-bottom:18px;text-transform:uppercase;position:relative}
-    .lp-s{max-width:var(--page-max);margin:0 auto;padding:56px 16px}
-    .lp-s h2{font-size:1.6rem;font-weight:800;margin:0 0 8px}
-    .lp-s .sub{color:var(--muted);margin:0 0 32px;font-size:1rem;max-width:780px}
-    .stats-band{background:linear-gradient(135deg,#fffdf4,#fff);border:1px solid rgba(212,175,55,.18);border-radius:18px;padding:28px;margin-top:24px;display:grid;grid-template-columns:repeat(4,1fr);gap:20px;text-align:center}
-    .stats-band .item small{font-size:.75rem;color:var(--muted);display:block;margin-bottom:4px;text-transform:uppercase;letter-spacing:.4px}
-    .stats-band .item strong{font-size:1.4rem;font-weight:800;color:var(--text)}
-    .stats-band .item strong.gold{color:var(--gold)}
-    @media(max-width:680px){.stats-band{grid-template-columns:repeat(2,1fr)}}
-    .features-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:18px}
-    .feature-card{background:#fff;border:1px solid rgba(17,24,39,.07);border-radius:14px;padding:22px;box-shadow:0 4px 14px rgba(0,0,0,.04)}
-    .feature-card .ico{font-size:1.8rem;margin-bottom:10px}
-    .feature-card h3{font-size:1rem;font-weight:700;margin:0 0 6px}
-    .feature-card p{font-size:.88rem;color:var(--muted);margin:0;line-height:1.5}
-    .invest-block{background:linear-gradient(135deg,#0b0b0b,#1a1a2e);color:#fff;border-radius:18px;padding:38px;margin-top:24px}
-    .invest-block h3{color:#fff;font-size:1.3rem;margin:0 0 8px}
-    .invest-block p{color:rgba(255,255,255,.75);margin:0 0 20px}
-    .invest-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:18px}
-    .invest-item{background:rgba(255,255,255,.05);border:1px solid rgba(212,175,55,.18);border-radius:12px;padding:18px}
-    .invest-item small{font-size:.72rem;color:rgba(255,255,255,.55);text-transform:uppercase;letter-spacing:.4px;display:block;margin-bottom:6px}
-    .invest-item strong{font-size:1.15rem;font-weight:800;color:var(--gold)}
-    @media(max-width:680px){.invest-grid{grid-template-columns:1fr}}
-    .lp-cta{text-align:center;padding:56px 16px;background:linear-gradient(180deg,#fffdf4,#fff)}
-    .lp-cta h2{font-size:1.6rem;font-weight:800;margin:0 0 12px}
-    .lp-cta p{color:var(--muted);margin:0 0 24px;font-size:1rem}
-    .related-links{display:flex;flex-wrap:wrap;gap:10px;justify-content:center;margin-top:28px}
-    .related-links a{padding:8px 16px;border:1px solid rgba(212,175,55,.3);border-radius:999px;color:var(--text);text-decoration:none;font-size:.88rem;font-weight:600;background:#fff;transition:all .2s}
-    .related-links a:hover{background:var(--gold);color:#000;border-color:var(--gold)}
-  </style>
 </head>
 <body>
   <a class="skip-link" href="#main">Saltar al contenido</a>

--- a/san-diego.html
+++ b/san-diego.html
@@ -23,40 +23,6 @@
   <script src="js/database.js" defer></script>
   <script src="js/cache-manager.js" defer></script>
   <script src="js/utils.js" defer></script>
-  <style>
-    .lp-hero{padding:calc(var(--header-h) + 56px) 16px 56px;text-align:center;background:linear-gradient(180deg,#0b0b0b,#1a1a2e);color:#fff;position:relative;overflow:hidden}
-    .lp-hero::before{content:'';position:absolute;inset:-50%;width:200%;height:200%;background:radial-gradient(ellipse at 30% 60%,rgba(212,175,55,.08),transparent 50%);pointer-events:none}
-    .lp-hero h1{font-size:clamp(1.8rem,5vw,2.8rem);font-weight:800;margin:0 0 12px;position:relative}
-    .lp-hero p{color:rgba(255,255,255,.7);font-size:1.05rem;max-width:680px;margin:0 auto;position:relative}
-    .hero-badge{display:inline-block;background:linear-gradient(135deg,var(--gold),var(--accent));color:#000;padding:6px 16px;border-radius:999px;font-size:.78rem;font-weight:800;letter-spacing:.5px;margin-bottom:18px;text-transform:uppercase;position:relative}
-    .lp-s{max-width:var(--page-max);margin:0 auto;padding:56px 16px}
-    .lp-s h2{font-size:1.6rem;font-weight:800;margin:0 0 8px}
-    .lp-s .sub{color:var(--muted);margin:0 0 32px;font-size:1rem;max-width:780px}
-    .stats-band{background:linear-gradient(135deg,#fffdf4,#fff);border:1px solid rgba(212,175,55,.18);border-radius:18px;padding:28px;margin-top:24px;display:grid;grid-template-columns:repeat(4,1fr);gap:20px;text-align:center}
-    .stats-band .item small{font-size:.75rem;color:var(--muted);display:block;margin-bottom:4px;text-transform:uppercase;letter-spacing:.4px}
-    .stats-band .item strong{font-size:1.4rem;font-weight:800;color:var(--text)}
-    .stats-band .item strong.gold{color:var(--gold)}
-    @media(max-width:680px){.stats-band{grid-template-columns:repeat(2,1fr)}}
-    .features-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:18px}
-    .feature-card{background:#fff;border:1px solid rgba(17,24,39,.07);border-radius:14px;padding:22px;box-shadow:0 4px 14px rgba(0,0,0,.04)}
-    .feature-card .ico{font-size:1.8rem;margin-bottom:10px}
-    .feature-card h3{font-size:1rem;font-weight:700;margin:0 0 6px}
-    .feature-card p{font-size:.88rem;color:var(--muted);margin:0;line-height:1.5}
-    .invest-block{background:linear-gradient(135deg,#0b0b0b,#1a1a2e);color:#fff;border-radius:18px;padding:38px;margin-top:24px}
-    .invest-block h3{color:#fff;font-size:1.3rem;margin:0 0 8px}
-    .invest-block p{color:rgba(255,255,255,.75);margin:0 0 20px}
-    .invest-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:18px}
-    .invest-item{background:rgba(255,255,255,.05);border:1px solid rgba(212,175,55,.18);border-radius:12px;padding:18px}
-    .invest-item small{font-size:.72rem;color:rgba(255,255,255,.55);text-transform:uppercase;letter-spacing:.4px;display:block;margin-bottom:6px}
-    .invest-item strong{font-size:1.15rem;font-weight:800;color:var(--gold)}
-    @media(max-width:680px){.invest-grid{grid-template-columns:1fr}}
-    .lp-cta{text-align:center;padding:56px 16px;background:linear-gradient(180deg,#fffdf4,#fff)}
-    .lp-cta h2{font-size:1.6rem;font-weight:800;margin:0 0 12px}
-    .lp-cta p{color:var(--muted);margin:0 0 24px;font-size:1rem}
-    .related-links{display:flex;flex-wrap:wrap;gap:10px;justify-content:center;margin-top:28px}
-    .related-links a{padding:8px 16px;border:1px solid rgba(212,175,55,.3);border-radius:999px;color:var(--text);text-decoration:none;font-size:.88rem;font-weight:600;background:#fff;transition:all .2s}
-    .related-links a:hover{background:var(--gold);color:#000;border-color:var(--gold)}
-  </style>
 </head>
 <body>
   <a class="skip-link" href="#main">Saltar al contenido</a>

--- a/serena-del-mar.html
+++ b/serena-del-mar.html
@@ -23,40 +23,6 @@
   <script src="js/database.js" defer></script>
   <script src="js/cache-manager.js" defer></script>
   <script src="js/utils.js" defer></script>
-  <style>
-    .lp-hero{padding:calc(var(--header-h) + 56px) 16px 56px;text-align:center;background:linear-gradient(180deg,#0b0b0b,#1a1a2e);color:#fff;position:relative;overflow:hidden}
-    .lp-hero::before{content:'';position:absolute;inset:-50%;width:200%;height:200%;background:radial-gradient(ellipse at 30% 60%,rgba(212,175,55,.08),transparent 50%);pointer-events:none}
-    .lp-hero h1{font-size:clamp(1.8rem,5vw,2.8rem);font-weight:800;margin:0 0 12px;position:relative}
-    .lp-hero p{color:rgba(255,255,255,.7);font-size:1.05rem;max-width:680px;margin:0 auto;position:relative}
-    .hero-badge{display:inline-block;background:linear-gradient(135deg,var(--gold),var(--accent));color:#000;padding:6px 16px;border-radius:999px;font-size:.78rem;font-weight:800;letter-spacing:.5px;margin-bottom:18px;text-transform:uppercase;position:relative}
-    .lp-s{max-width:var(--page-max);margin:0 auto;padding:56px 16px}
-    .lp-s h2{font-size:1.6rem;font-weight:800;margin:0 0 8px}
-    .lp-s .sub{color:var(--muted);margin:0 0 32px;font-size:1rem;max-width:780px}
-    .stats-band{background:linear-gradient(135deg,#fffdf4,#fff);border:1px solid rgba(212,175,55,.18);border-radius:18px;padding:28px;margin-top:24px;display:grid;grid-template-columns:repeat(4,1fr);gap:20px;text-align:center}
-    .stats-band .item small{font-size:.75rem;color:var(--muted);display:block;margin-bottom:4px;text-transform:uppercase;letter-spacing:.4px}
-    .stats-band .item strong{font-size:1.4rem;font-weight:800;color:var(--text)}
-    .stats-band .item strong.gold{color:var(--gold)}
-    @media(max-width:680px){.stats-band{grid-template-columns:repeat(2,1fr)}}
-    .features-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:18px}
-    .feature-card{background:#fff;border:1px solid rgba(17,24,39,.07);border-radius:14px;padding:22px;box-shadow:0 4px 14px rgba(0,0,0,.04)}
-    .feature-card .ico{font-size:1.8rem;margin-bottom:10px}
-    .feature-card h3{font-size:1rem;font-weight:700;margin:0 0 6px}
-    .feature-card p{font-size:.88rem;color:var(--muted);margin:0;line-height:1.5}
-    .invest-block{background:linear-gradient(135deg,#0b0b0b,#1a1a2e);color:#fff;border-radius:18px;padding:38px;margin-top:24px}
-    .invest-block h3{color:#fff;font-size:1.3rem;margin:0 0 8px}
-    .invest-block p{color:rgba(255,255,255,.75);margin:0 0 20px}
-    .invest-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:18px}
-    .invest-item{background:rgba(255,255,255,.05);border:1px solid rgba(212,175,55,.18);border-radius:12px;padding:18px}
-    .invest-item small{font-size:.72rem;color:rgba(255,255,255,.55);text-transform:uppercase;letter-spacing:.4px;display:block;margin-bottom:6px}
-    .invest-item strong{font-size:1.15rem;font-weight:800;color:var(--gold)}
-    @media(max-width:680px){.invest-grid{grid-template-columns:1fr}}
-    .lp-cta{text-align:center;padding:56px 16px;background:linear-gradient(180deg,#fffdf4,#fff)}
-    .lp-cta h2{font-size:1.6rem;font-weight:800;margin:0 0 12px}
-    .lp-cta p{color:var(--muted);margin:0 0 24px;font-size:1rem}
-    .related-links{display:flex;flex-wrap:wrap;gap:10px;justify-content:center;margin-top:28px}
-    .related-links a{padding:8px 16px;border:1px solid rgba(212,175,55,.3);border-radius:999px;color:var(--text);text-decoration:none;font-size:.88rem;font-weight:600;background:#fff;transition:all .2s}
-    .related-links a:hover{background:var(--gold);color:#000;border-color:var(--gold)}
-  </style>
 </head>
 <body>
   <a class="skip-link" href="#main">Saltar al contenido</a>

--- a/style.css
+++ b/style.css
@@ -820,3 +820,37 @@ img[data-src].loaded {
 .sector-card-skeleton .sk-line.w-80 { width: 80%; }
 .sector-card-skeleton .sk-line.w-60 { width: 60%; }
 .sector-card-skeleton .sk-line.w-40 { width: 40%; }
+
+/* ── Landing pages de sector ───────────────────────── */
+.lp-hero{padding:calc(var(--header-h) + 56px) 16px 56px;text-align:center;background:linear-gradient(180deg,#0b0b0b,#1a1a2e);color:#fff;position:relative;overflow:hidden}
+.lp-hero::before{content:'';position:absolute;inset:-50%;width:200%;height:200%;background:radial-gradient(ellipse at 30% 60%,rgba(212,175,55,.08),transparent 50%);pointer-events:none}
+.lp-hero h1{font-size:clamp(1.8rem,5vw,2.8rem);font-weight:800;margin:0 0 12px;position:relative}
+.lp-hero p{color:rgba(255,255,255,.7);font-size:1.05rem;max-width:680px;margin:0 auto;position:relative}
+.hero-badge{display:inline-block;background:linear-gradient(135deg,var(--gold),var(--accent));color:#000;padding:6px 16px;border-radius:999px;font-size:.78rem;font-weight:800;letter-spacing:.5px;margin-bottom:18px;text-transform:uppercase;position:relative}
+.lp-s{max-width:var(--page-max);margin:0 auto;padding:56px 16px}
+.lp-s h2{font-size:1.6rem;font-weight:800;margin:0 0 8px}
+.lp-s .sub{color:var(--muted);margin:0 0 32px;font-size:1rem;max-width:780px}
+.stats-band{background:linear-gradient(135deg,#fffdf4,#fff);border:1px solid rgba(212,175,55,.18);border-radius:18px;padding:28px;margin-top:24px;display:grid;grid-template-columns:repeat(4,1fr);gap:20px;text-align:center}
+.stats-band .item small{font-size:.75rem;color:var(--muted);display:block;margin-bottom:4px;text-transform:uppercase;letter-spacing:.4px}
+.stats-band .item strong{font-size:1.4rem;font-weight:800;color:var(--text)}
+.stats-band .item strong.gold{color:var(--gold)}
+@media(max-width:680px){.stats-band{grid-template-columns:repeat(2,1fr)}}
+.features-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:18px}
+.feature-card{background:#fff;border:1px solid rgba(17,24,39,.07);border-radius:14px;padding:22px;box-shadow:0 4px 14px rgba(0,0,0,.04)}
+.feature-card .ico{font-size:1.8rem;margin-bottom:10px}
+.feature-card h3{font-size:1rem;font-weight:700;margin:0 0 6px}
+.feature-card p{font-size:.88rem;color:var(--muted);margin:0;line-height:1.5}
+.invest-block{background:linear-gradient(135deg,#0b0b0b,#1a1a2e);color:#fff;border-radius:18px;padding:38px;margin-top:24px}
+.invest-block h3{color:#fff;font-size:1.3rem;margin:0 0 8px}
+.invest-block p{color:rgba(255,255,255,.75);margin:0 0 20px}
+.invest-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:18px}
+.invest-item{background:rgba(255,255,255,.05);border:1px solid rgba(212,175,55,.18);border-radius:12px;padding:18px}
+.invest-item small{font-size:.72rem;color:rgba(255,255,255,.55);text-transform:uppercase;letter-spacing:.4px;display:block;margin-bottom:6px}
+.invest-item strong{font-size:1.15rem;font-weight:800;color:var(--gold)}
+@media(max-width:680px){.invest-grid{grid-template-columns:1fr}}
+.lp-cta{text-align:center;padding:56px 16px;background:linear-gradient(180deg,#fffdf4,#fff)}
+.lp-cta h2{font-size:1.6rem;font-weight:800;margin:0 0 12px}
+.lp-cta p{color:var(--muted);margin:0 0 24px;font-size:1rem}
+.related-links{display:flex;flex-wrap:wrap;gap:10px;justify-content:center;margin-top:28px}
+.related-links a{padding:8px 16px;border:1px solid rgba(212,175,55,.3);border-radius:999px;color:var(--text);text-decoration:none;font-size:.88rem;font-weight:600;background:#fff;transition:all .2s}
+.related-links a:hover{background:var(--gold);color:#000;border-color:var(--gold)}

--- a/tierrabomba.html
+++ b/tierrabomba.html
@@ -23,40 +23,6 @@
   <script src="js/database.js" defer></script>
   <script src="js/cache-manager.js" defer></script>
   <script src="js/utils.js" defer></script>
-  <style>
-    .lp-hero{padding:calc(var(--header-h) + 56px) 16px 56px;text-align:center;background:linear-gradient(180deg,#0b0b0b,#1a1a2e);color:#fff;position:relative;overflow:hidden}
-    .lp-hero::before{content:'';position:absolute;inset:-50%;width:200%;height:200%;background:radial-gradient(ellipse at 30% 60%,rgba(212,175,55,.08),transparent 50%);pointer-events:none}
-    .lp-hero h1{font-size:clamp(1.8rem,5vw,2.8rem);font-weight:800;margin:0 0 12px;position:relative}
-    .lp-hero p{color:rgba(255,255,255,.7);font-size:1.05rem;max-width:680px;margin:0 auto;position:relative}
-    .hero-badge{display:inline-block;background:linear-gradient(135deg,var(--gold),var(--accent));color:#000;padding:6px 16px;border-radius:999px;font-size:.78rem;font-weight:800;letter-spacing:.5px;margin-bottom:18px;text-transform:uppercase;position:relative}
-    .lp-s{max-width:var(--page-max);margin:0 auto;padding:56px 16px}
-    .lp-s h2{font-size:1.6rem;font-weight:800;margin:0 0 8px}
-    .lp-s .sub{color:var(--muted);margin:0 0 32px;font-size:1rem;max-width:780px}
-    .stats-band{background:linear-gradient(135deg,#fffdf4,#fff);border:1px solid rgba(212,175,55,.18);border-radius:18px;padding:28px;margin-top:24px;display:grid;grid-template-columns:repeat(4,1fr);gap:20px;text-align:center}
-    .stats-band .item small{font-size:.75rem;color:var(--muted);display:block;margin-bottom:4px;text-transform:uppercase;letter-spacing:.4px}
-    .stats-band .item strong{font-size:1.4rem;font-weight:800;color:var(--text)}
-    .stats-band .item strong.gold{color:var(--gold)}
-    @media(max-width:680px){.stats-band{grid-template-columns:repeat(2,1fr)}}
-    .features-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:18px}
-    .feature-card{background:#fff;border:1px solid rgba(17,24,39,.07);border-radius:14px;padding:22px;box-shadow:0 4px 14px rgba(0,0,0,.04)}
-    .feature-card .ico{font-size:1.8rem;margin-bottom:10px}
-    .feature-card h3{font-size:1rem;font-weight:700;margin:0 0 6px}
-    .feature-card p{font-size:.88rem;color:var(--muted);margin:0;line-height:1.5}
-    .invest-block{background:linear-gradient(135deg,#0b0b0b,#1a1a2e);color:#fff;border-radius:18px;padding:38px;margin-top:24px}
-    .invest-block h3{color:#fff;font-size:1.3rem;margin:0 0 8px}
-    .invest-block p{color:rgba(255,255,255,.75);margin:0 0 20px}
-    .invest-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:18px}
-    .invest-item{background:rgba(255,255,255,.05);border:1px solid rgba(212,175,55,.18);border-radius:12px;padding:18px}
-    .invest-item small{font-size:.72rem;color:rgba(255,255,255,.55);text-transform:uppercase;letter-spacing:.4px;display:block;margin-bottom:6px}
-    .invest-item strong{font-size:1.15rem;font-weight:800;color:var(--gold)}
-    @media(max-width:680px){.invest-grid{grid-template-columns:1fr}}
-    .lp-cta{text-align:center;padding:56px 16px;background:linear-gradient(180deg,#fffdf4,#fff)}
-    .lp-cta h2{font-size:1.6rem;font-weight:800;margin:0 0 12px}
-    .lp-cta p{color:var(--muted);margin:0 0 24px;font-size:1rem}
-    .related-links{display:flex;flex-wrap:wrap;gap:10px;justify-content:center;margin-top:28px}
-    .related-links a{padding:8px 16px;border:1px solid rgba(212,175,55,.3);border-radius:999px;color:var(--text);text-decoration:none;font-size:.88rem;font-weight:600;background:#fff;transition:all .2s}
-    .related-links a:hover{background:var(--gold);color:#000;border-color:var(--gold)}
-  </style>
 </head>
 <body>
   <a class="skip-link" href="#main">Saltar al contenido</a>


### PR DESCRIPTION
Move 34 shared CSS rules (lp-hero, stats-band, features-grid, feature-card, invest-block, lp-cta, related-links) from inline <style> in each landing page to style.css. Removes 408 duplicate lines, adds 34 centralized lines.

Zero visual changes — same selectors and values, just one source of truth.

https://claude.ai/code/session_01EES3HSNiBjVcrCrext96rr