### PR TITLE
feat(cerebro): kernel v1.2 + skill auditoria-cerebro + template 1.1.0…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- brain-template-version: 1.0.0 -->
+<!-- brain-template-version: 1.1.0 -->
 # CLAUDE.md — Altorra Inmobiliaria · 🧠 Tronco Encefálico (Router Neuronal)
 
 > **Este archivo se auto-carga en CADA sesión.** Es el enrutador central del
@@ -162,9 +162,11 @@ Al iniciar una conversación nueva estás **estrictamente obligado** a leer SOLO
 ### G.3 — Protocolo de Consolidación (sinapsis)
 La memoria fluye en una dirección: Corto Plazo → Largo Plazo. **Por cada tarea finalizada**: actualiza `10`. **Cuando se cierra por completo**: MUEVE el recuerdo a `99` (ADR, formato §2) + fila en `00`, marca su `TODO-NN` ✅, y retíralo de `10`. **Regla de Oro**: NUNCA documentes historial ni tareas en este `CLAUDE.md`.
 
+**Regla de PROPIEDAD (SSoT)**: un hecho = UN nodo dueño; el resto APUNTA (estado→05 · dominio→lóbulo · WIP→10 · decisión→99). **Regla de ADMISIÓN (anti-teatro)**: toda regla nueva declara su gate del linter o lleva [HONOR] explícito.
+
 ### G.4 — Sistema Autónomo de Auto-construcción (neuroplasticidad, bajo TU guía)
 Reflejos VINCULANTES que disparas con juicio durante el trabajo normal, **sin que el usuario los pida**:
-- **Captura**: TODO conocimiento reutilizable → su neurona ANTES de cerrar (bug/lección → `30`; arquitectura → `20`; WIP → `10`; decisión cerrada → `99` + `00`). **Deliberación** (comité / consejo externo / workflow, cara de reproducir) → CRUDO a `docs/research-archive/` (`archiveDir` del manifest) + SÍNTESIS con *callejones probados* ANTES de cerrar (el sacrificio de investigación ES conocimiento; perderlo = re-investigar).
+- **Captura**: TODO conocimiento reutilizable → su neurona ANTES de cerrar (bug/lección → `30`; arquitectura → `20`; WIP → `10`; decisión cerrada → `99` + `00`). **Deliberación** (comité / consejo externo / workflow, cara de reproducir) → CRUDO al `archiveDir` del manifest (bóveda privada `../brain-private/`) + SÍNTESIS con *callejones probados* ANTES de cerrar (el sacrificio de investigación ES conocimiento; perderlo = re-investigar).
 - **Neurogénesis**: conocimiento reutilizable que no encaja y crecerá → crea `docs/NN-NOMBRE.md` + (1) fila en §0, (2) registro en `00`, (3) bitácora. Anti-fragmentación: si dudas, apéndalo. Lóbulos hijos (`41`…) solo con contenido real (Trigger 🔵).
 - **Frescura**: si mueves/creas/renombras/eliminas un componente/ruta/flujo → actualiza `20` en el MISMO cambio.
 - **Higiene = GC**: `10` es pizarra (cap ~110). Al cerrar tarea, si supera el cap → poda: consolida a `99`/`30`, recorta `10` al foco vivo. ⛔ Nunca volcar a `99` sin convertir en ADR.

--- a/docs/.brain-manifest.json
+++ b/docs/.brain-manifest.json
@@ -1,5 +1,5 @@
 {
-  "brainTemplateVersion": "1.0.0",
+  "brainTemplateVersion": "1.1.0",
   "repo": "altorrainmobiliaria",
   "_comment": "Config INSTANCE del cerebro (topes/budgets). El linter scripts/brain-check.mjs es KERNEL (idéntico en los 3 repos); estos budgets son por-repo. chars = unidad real de contexto (plan v5 §6). NO auto-cargado: solo lo lee el linter.",
   "bootCharsTarget": 31500,
@@ -38,5 +38,24 @@
       "chars": 16000
     }
   },
-  "archiveDir": "docs/research-archive"
+  "archiveDir": "../brain-private/altorrainmobiliaria/research-archive",
+  "staleDays": 10,
+  "kernelFiles": [
+    "scripts/brain-check.mjs",
+    "scripts/brain-diff.mjs"
+  ],
+  "ignoreDirs": [
+    "bersaglio-design"
+  ],
+  "orphanAllowlist": [],
+  "peers": [
+    "../altorracars.github.io",
+    "../bersagliojewelry.github.io"
+  ],
+  "deepAudit": {
+    "last": "2026-06-09",
+    "coveredHeaderCount": null,
+    "maxAdrGap": 12,
+    "maxDays": 30
+  }
 }

--- a/docs/research-archive/README.md
+++ b/docs/research-archive/README.md
@@ -1,10 +1,5 @@
-# 📦 research-archive — Investigación CRUDA de deliberaciones
+# 📦 research-archive — MOVIDO a la bóveda privada
 
-> Salidas COMPLETAS (sin sintetizar) de deliberaciones caras de reproducir (comité de expertos,
-> consejo externo, workflows multi-agente). **Reflejo de Captura §G.4**: el CRUDO se archiva aquí
-> + la SÍNTESIS (con *callejones probados*) va al spec/ADR correspondiente, ANTES de cerrar la tarea.
-> Ruta canónica = `archiveDir` en `docs/.brain-manifest.json`. NO leer enteros (grandes) — grep/offset.
-
-| Archivo | KB | Qué es | Síntesis durable en |
-|---|---|---|---|
-| _(vacío — primera deliberación de este repo pendiente)_ | | | |
+> Los crudos de deliberación viven en la bóveda privada (ADR §174 de cars, consejo Gemini):
+> `../brain-private/altorrainmobiliaria/research-archive/` — es el `archiveDir` del manifest
+> (`docs/.brain-manifest.json`); el linter (check #7) y el Reflejo de Captura §G.4 resuelven contra esa clave.

--- a/docs/skills-inventory.md
+++ b/docs/skills-inventory.md
@@ -72,3 +72,4 @@
 | `verification-before-completion` | Use when about to claim work is complete, fixed, or passing, before committing or creating PRs - requires running verification commands and confirming |
 | `writing-plans` | Use when you have a spec or requirements for a multi-step task, before touching code |
 | `writing-skills` | Use when creating new skills, editing existing skills, or verifying skills work before deployment |
+| `auditoria-cerebro` (2026-06-09) | 🔬 Auditoría Nivel-2 del cerebro (sondas falsables: fidelidad/frescura/retrieval-drill/MEMORY.md; cierra con GC pareado + deepAudit). Nace del comité v6 (ADR §173 cars). Byte-idéntica ×3. |

--- a/package.json
+++ b/package.json
@@ -4,13 +4,14 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test":                  "node tests/validate-site.mjs",
-    "generate":              "node scripts/generate-properties.mjs",
-    "upload":                "node scripts/upload-to-firestore.mjs",
-    "migrate-images":        "node scripts/migrate-images-to-storage.mjs",
+    "test": "node tests/validate-site.mjs",
+    "generate": "node scripts/generate-properties.mjs",
+    "upload": "node scripts/upload-to-firestore.mjs",
+    "migrate-images": "node scripts/migrate-images-to-storage.mjs",
     "delete-all-properties": "node scripts/delete-all-properties.mjs",
-    "backup":                "node scripts/backup-firestore.mjs",
-    "brain:check":           "node scripts/brain-check.mjs"
+    "backup": "node scripts/backup-firestore.mjs",
+    "brain:check": "node scripts/brain-check.mjs",
+    "brain:diff": "node scripts/brain-diff.mjs"
   },
   "dependencies": {
     "firebase": "^12.9.0"

--- a/scripts/brain-check.mjs
+++ b/scripts/brain-check.mjs
@@ -1,61 +1,78 @@
 #!/usr/bin/env node
 // ===========================================================
-// 🧠 brain-check — Linter de integridad del cerebro neuronal (CANÓNICO · portable)
+// 🧠 brain-check v1.2 — Linter de integridad del cerebro neuronal (CANÓNICO · portable)
 // ===========================================================
-// KERNEL del cerebro multi-proyecto (ADR §170 / plan v5). Este archivo es IDÉNTICO
+// KERNEL del cerebro multi-proyecto (ADR §170/§171/§173). Este archivo es IDÉNTICO
 // en los 3 repos (cars/bersaglio/inmobiliaria) — canon = bersaglio (single-writer).
-// Los TOPES/budgets son INSTANCE: viven en docs/.brain-manifest.json por-repo.
-// READ-ONLY: reporta problemas, no modifica nada. Sin dependencias de child_process.
+// Los DATOS (topes/budgets/rutas/peers) son INSTANCE: viven en docs/.brain-manifest.json.
+// ⚠️ La SEVERIDAD de cada gate está HARDCODEADA aquí (anti green-tuning, ADR §173):
+// el manifest NUNCA puede degradar un warn; solo aporta datos. Campo `downgrades`
+// (con ADR citado) se IMPRIME en cada corrida — visible, no silencioso.
+// READ-ONLY: reporta, no modifica. Sin child_process (portabilidad + byte-identidad ×3).
 //
 //   node scripts/brain-check.mjs           → --full (default): TODO (pre-commit / manual)
-//   node scripts/brain-check.mjs --boot    → arranque LIVIANO: NO lee 99-HISTORIAL (~43k L)
+//   node scripts/brain-check.mjs --boot    → arranque LIVIANO + SILENCIOSO (presupuesto de stdout;
+//                                            NO lee 99-HISTORIAL; el hook re-inyecta cada línea)
 //
-// Chequea:
-//   (1) Neuronas huérfanas (docs/NN-*.md referenciada en CLAUDE.md; 41-49 vía 40-LOBULOS).
-//   (2) Capacidad §G.5 — chars (unidad real de contexto) + líneas, desde el manifest, + sub-presupuesto de BOOT.
-//   (3) Desync 00-INDICE → 99-HISTORIAL [solo --full · lee el 99].
-//   (4) Frescura OPCIONAL: cache SW (Altorra service-worker.js | genérico public/sw.js).
-//   (5) Referencias cruzadas: (5a ADR↔índice)(5b L-/M-↔30) [solo --full · leen 99/30] · (5c hojas) [siempre].
-//   (6) Skills del repo catalogadas en skills-inventory [solo --full].
-//
-// Diseño: chequeos universales fallan; opcionales solo informan. Convención-agnóstico
-// (headers numerados "## NN." o por fecha). El SessionStart usa --boot.
+// Checks (severidad fija):
+//   (1) Neuronas huérfanas registradas [warn]            (7) Integridad archiveDir: archivos↔README↔refs [warn, --full]
+//   (2) Caps chars+líneas [warn] · pre-shard ≥90% [info] (8) SSoT: hecho duplicado fuera del nodo dueño [warn, --full]
+//       · boot-budget [info: condición ×3 no cumplida]   (9) Consolidado-aún-en-10: fila ✅+§NN indexado [warn, --full]
+//   (3) Desync 00→99 [warn, --full]                     (10) BFS huérfanas 2º orden sobre grafo de ruteo [warn, --full]
+//   (4) Frescura cache SW↔05 [warn, opcional]           (11) Peer-hash kernelFiles ×3 [warn; peer ausente=info, --full]
+//   (5) Refs cruzadas ADR/L-M/hojas [warn]              (12) Fechas stale en 05/10 [info, --boot]
+//   (6) Skills↔inventario [warn, --full]                (13) Specs: checklist sin evidencia [warn] / sin checklist [info, --full]
+//                                                       (14) deepAudit Nivel-2 vencida [info nudge]
+//                                                       (15) Schema del manifest: clave desconocida [warn]
 // ===========================================================
 import { readFileSync, readdirSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { createHash } from 'crypto';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const DOCS = join(ROOT, 'docs');
 let problems = 0;
-const warn = (m) => { console.log('  ⚠️  ' + m); problems++; };
-const ok = (m) => console.log('  ✅ ' + m);
-const info = (m) => console.log('  ℹ️  ' + m);
-const read = (p) => readFileSync(p, 'utf-8');
-
-// --boot: arranque liviano (NO lee 99-HISTORIAL). default/--full: todo (plan v5 §6.7).
 const BOOT = process.argv.includes('--boot');
+// Presupuesto de stdout en --boot (el SessionStart re-inyecta CADA línea como contexto).
+const lines = [];
+const say = (m) => { lines.push(m); };
+const warn = (m) => { say('  ⚠️  ' + m); problems++; };
+const ok = (m) => { if (!BOOT) say('  ✅ ' + m); };
+const info = (m) => say('  ℹ️  ' + m);
+const head = (m) => { if (!BOOT) say(m); };
+const read = (p) => readFileSync(p, 'utf-8');
+const norm = (s) => s.replace(/\r\n/g, '\n'); // CRLF-normalizado (autocrlf ×3)
+const sha = (s) => createHash('sha256').update(norm(s)).digest('hex');
 
-console.log(`\n🧠 BRAIN-CHECK${BOOT ? ' --boot (liviano)' : ''} — integridad del cerebro neuronal\n`);
+say(`\n🧠 BRAIN-CHECK v1.2${BOOT ? ' --boot (liviano+silencioso)' : ' --full'} — integridad del cerebro\n`);
 
-// Pre-flight: las piezas críticas existen.
+// Pre-flight
 const CLAUDE_PATH = join(ROOT, 'CLAUDE.md');
-if (!existsSync(CLAUDE_PATH)) {
-  console.log('  ⚠️  CLAUDE.md no existe en la raíz — ¿estás corriendo el linter desde el directorio correcto?');
-  process.exit(1);
-}
-if (!existsSync(DOCS)) {
-  console.log('  ⚠️  docs/ no existe — el cerebro no está cableado.');
+if (!existsSync(CLAUDE_PATH) || !existsSync(DOCS)) {
+  console.log('  ⚠️  CLAUDE.md o docs/ no existe — ¿directorio correcto? Cerebro no cableado.');
   process.exit(1);
 }
 
-// Config INSTANCE (topes/budgets) desde docs/.brain-manifest.json. Si no existe, defaults por líneas.
+// ---- Manifest (DATOS instance; jamás severidades) + validación de schema (#15) ----
 const MANIFEST_PATH = join(DOCS, '.brain-manifest.json');
 let manifest = {};
 if (existsSync(MANIFEST_PATH)) {
   try { manifest = JSON.parse(read(MANIFEST_PATH)); }
-  catch { info('.brain-manifest.json ilegible (JSON inválido) — usando defaults de líneas'); }
+  catch { info('.brain-manifest.json ilegible (JSON inválido) — defaults'); }
 }
+const KNOWN_KEYS = new Set([
+  'brainTemplateVersion', 'repo', 'bootCharsTarget', 'alwaysOn', 'caps', 'archiveDir',
+  'deepAudit', 'peers', 'kernelFiles', 'ssotFacts', 'specsDir', 'staleDays', 'ignoreDirs',
+  'downgrades', 'orphanAllowlist',
+]);
+for (const k of Object.keys(manifest)) {
+  if (!k.startsWith('_') && !KNOWN_KEYS.has(k)) warn(`manifest: clave desconocida "${k}" (¿typo? un typo apaga gates en silencio) — schema v1.2`);
+}
+if (Array.isArray(manifest.downgrades) && manifest.downgrades.length) {
+  for (const d of manifest.downgrades) info(`DOWNGRADE activo: ${typeof d === 'string' ? d : JSON.stringify(d)} (visible por diseño — exige ADR)`);
+}
+
 const DEFAULT_CAPS = {
   'CLAUDE.md': { lines: 320 }, 'docs/05-ESTADO-GLOBAL.md': { lines: 25 },
   'docs/10-MEMORIA-CORTO-PLAZO.md': { lines: 110 }, 'docs/20-MEMORIA-ESPACIAL.md': { lines: 280 },
@@ -69,55 +86,59 @@ const BOOT_CHARS_TARGET = manifest.bootCharsTarget || null;
 const claude = read(CLAUDE_PATH);
 const indicePath = join(DOCS, '00-INDICE.md');
 const histPath = join(DOCS, '99-HISTORIAL-ADR.md');
-
-// Registry de lóbulos: los hijos (41-49) NO viven en CLAUDE.md §0 — se registran en 40-LOBULOS-DOMINIO.md.
 const lobeRegistryPath = join(DOCS, '40-LOBULOS-DOMINIO.md');
 const lobeRegistry = existsSync(lobeRegistryPath) ? read(lobeRegistryPath) : '';
 
-// 1) Neuronas huérfanas
-console.log('1) Neuronas huérfanas (registradas en CLAUDE.md / 40-LOBULOS):');
+// 1) Neuronas huérfanas (registro directo)
+head('1) Neuronas huérfanas (registradas en CLAUDE.md / 40-LOBULOS):');
 const neurons = readdirSync(DOCS).filter((f) => /^\d{2}-.*\.md$/.test(f));
+let okNeurons = 0;
 for (const n of neurons) {
   const isChildLobe = /^4[1-9]-/.test(n);
-  if (claude.includes(n)) ok(`${n}`);
-  else if (isChildLobe && lobeRegistry.includes(n)) ok(`${n} (lóbulo hijo → 40-LOBULOS-DOMINIO)`);
+  if (claude.includes(n)) { ok(`${n}`); okNeurons++; }
+  else if (isChildLobe && lobeRegistry.includes(n)) { ok(`${n} (lóbulo hijo → 40-LOBULOS)`); okNeurons++; }
   else if (isChildLobe) warn(`${n} lóbulo hijo NO registrado en 40-LOBULOS-DOMINIO`);
   else warn(`${n} NO referenciada en CLAUDE.md → HUÉRFANA (conectar en §0)`);
 }
+if (BOOT && okNeurons === neurons.length) say(`  ✅ ${okNeurons} neuronas registradas`);
 
-// 2) Capacidad (§G.5) — chars = unidad REAL de contexto (manifest); líneas = compat.
-console.log('\n2) Capacidad de neuronas (§G.5 · chars = unidad real de contexto):');
+// 2) Capacidad (§G.5) + pre-shard 90% + boot-budget
+head('\n2) Capacidad de neuronas (§G.5 · chars = unidad real de contexto):');
 let bootChars = 0;
+const preShard = [];
+let okCaps = 0, capCount = 0;
 for (const [rel, cap] of Object.entries(CAPS)) {
   const p = join(ROOT, rel);
-  if (!existsSync(p)) continue; // capado pero ausente en este repo → omitir (portable)
+  if (!existsSync(p)) continue;
+  capCount++;
   const txt = read(p);
-  const lines = txt.split('\n').length;
+  const nLines = txt.split('\n').length;
   const chars = txt.length;
   if (ALWAYS_ON.includes(rel)) bootChars += chars;
   const lc = cap.lines, cc = cap.chars;
-  const over = (lc && lines > Math.round(lc * 1.1)) || (cc && chars > Math.round(cc * 1.1));
-  const nudge = (lc && lines > lc) || (cc && chars > cc);
-  const tag = cc ? `${chars}c/${cc} · ${lines}L/${lc}` : `${lines}L/${lc} (${chars}c)`;
+  const over = (lc && nLines > Math.round(lc * 1.1)) || (cc && chars > Math.round(cc * 1.1));
+  const nudge = (lc && nLines > lc) || (cc && chars > cc);
+  const near = (cc && chars >= Math.round(cc * 0.9)) || (lc && nLines >= Math.round(lc * 0.9));
+  const tag = cc ? `${chars}c/${cc} · ${nLines}L/${lc}` : `${nLines}L/${lc} (${chars}c)`;
   if (over) warn(`${rel}: ${tag} → SHARD/poda (excede tope)`);
-  else if (nudge) console.log(`  ↗  ${rel}: ${tag} (leve exceso — destilar)`);
-  else ok(`${rel}: ${tag}`);
+  else if (nudge) say(`  ↗  ${rel}: ${tag} (leve exceso — destilar)`);
+  else { ok(`${rel}: ${tag}`); okCaps++; if (near) preShard.push(rel); }
 }
+if (BOOT && okCaps) say(`  ✅ ${okCaps}/${capCount} neuronas dentro de tope`);
+if (preShard.length) info(`pre-shard: ${preShard.length} neurona(s) ≥90% de su cap (${preShard.join(', ')}) — planear shard/GC ANTES de reventar`);
 if (BOOT_CHARS_TARGET) {
   const bootTok = Math.round(bootChars / 3.5);
-  // INFORMATIVO por diseño (NO incrementa problems / NO afecta exit-code): el objetivo de boot es
-  // aspiracional; el exceso se reduce destilando o difiriendo superficie always-on, NO es un fallo
-  // bloqueante. Honesto: nudge declarado, no un símbolo que finge ser warning (anti-teatro de proceso).
+  // INFORMATIVO por diseño MIENTRAS los 3 repos no estén bajo presupuesto (condición §173;
+  // al cumplirse ×3, este gate sube a warn EN EL KERNEL, no por manifest).
   if (bootChars > Math.round(BOOT_CHARS_TARGET * 1.1))
-    console.log(`  ℹ️  BOOT always-on = ${bootChars}c (~${bootTok} tok) vs objetivo ${BOOT_CHARS_TARGET}c — informativo (aspiracional; destilar/diferir, NO bloquea)`);
-  else ok(`BOOT always-on = ${bootChars}c (~${bootTok} tok) ≤ objetivo ${BOOT_CHARS_TARGET}c`);
+    info(`BOOT always-on = ${bootChars}c (~${bootTok} tok) vs objetivo ${BOOT_CHARS_TARGET}c — destilar/diferir (informativo)`);
+  else say(`  ✅ BOOT always-on = ${bootChars}c (~${bootTok} tok) ≤ objetivo ${BOOT_CHARS_TARGET}c`);
 }
 
-// 3) Desync del índice → 99 (LEE el 99 ~43k líneas) — solo en --full.
-console.log('\n3) Desync índice 00-INDICE → 99-HISTORIAL (fragilidad offset):');
-if (BOOT) {
-  console.log('  ⏭️  omitido en --boot (lee 99-HISTORIAL) → corre en pre-commit / npm run brain:check');
-} else if (existsSync(indicePath) && existsSync(histPath)) {
+// 3) Desync índice → 99 [--full]
+head('\n3) Desync índice 00-INDICE → 99-HISTORIAL:');
+if (BOOT) { head('  ⏭️  omitido en --boot'); }
+else if (existsSync(indicePath) && existsSync(histPath)) {
   const indice = read(indicePath).split('\n');
   const hist = read(histPath).split('\n');
   const numberedConvention = hist.some((l) => /^##\s+\d+\.\s/.test(l));
@@ -130,17 +151,15 @@ if (BOOT) {
     checked++;
     if (!/^##\s/.test(target)) { warn(`§${sec} → línea ${ln} NO es un header (desync: "${target.slice(0, 40)}")`); desync++; }
     else if (numberedConvention && /^\d+$/.test(sec.split('.')[0]) && !new RegExp(`^##\\s+${sec.split('.')[0]}[.\\s]`).test(target)) {
-      warn(`§${sec} → línea ${ln} apunta a OTRO § ("${target.replace(/^##\s*/, '').slice(0, 28)}…") → offset drift`); desync++;
+      warn(`§${sec} → línea ${ln} apunta a OTRO § → offset drift`); desync++;
     }
   }
-  if (!checked) info('índice vacío (sin ADRs todavía) — chequeo omitido');
-  else if (!desync) ok(`${checked} entradas del índice apuntan a headers válidos${numberedConvention ? ' (+ número §)' : ' (convención por fecha)'}`);
-} else {
-  info('00-INDICE.md o 99-HISTORIAL-ADR.md no existe — chequeo omitido');
+  if (!checked) info('índice sin filas § — omitido');
+  else if (!desync) ok(`${checked} entradas del índice apuntan a headers válidos`);
 }
 
-// 4) Frescura OPCIONAL (cache SW) — barato, siempre. Solo aplica si el proyecto declara §4 + SW existe.
-console.log('\n4) Frescura (cache SW ↔ 05) — OPCIONAL:');
+// 4) Frescura cache SW ↔ 05 (opcional)
+head('\n4) Frescura (cache SW ↔ 05) — OPCIONAL:');
 const hasSwSection = /##\s*§4\s*—\s*Cache bump/i.test(claude);
 const swCandidates = ['service-worker.js', 'public/sw.js', 'sw.js', 'public/service-worker.js'];
 let swFile = null;
@@ -150,18 +169,14 @@ if (hasSwSection && swFile) {
   const swVer =
     (swSrc.match(/CACHE_VERSION\s*=\s*'v?(\d{14})'/) || [])[1] ||
     (swSrc.match(/CACHE_(?:NAME|VERSION)\s*=\s*['"]([^'"]+)['"]/) || [])[1] || null;
-  if (!swVer) {
-    info(`encontré ${swFile} pero no pude parsear CACHE_NAME/CACHE_VERSION (¿cambió el formato?)`);
-  } else {
-    info(`service-worker: ${swFile} → cache "${swVer}"`);
+  if (!swVer) info(`${swFile} sin CACHE_NAME/CACHE_VERSION parseable`);
+  else {
+    head(`  ℹ️  service-worker: ${swFile} → cache "${swVer}"`);
     const cmCandidates = ['js/core/cache-manager.js', 'src/cache-manager.js', 'src/lib/cache-manager.js'];
     let cmVer = null, cmPath = null;
     for (const c of cmCandidates) {
       const p = join(ROOT, c);
-      if (existsSync(p)) {
-        const v = (read(p).match(/APP_VERSION\s*=\s*'v?(\d{14})'/) || [])[1];
-        if (v) { cmVer = v; cmPath = c; break; }
-      }
+      if (existsSync(p)) { const v = (read(p).match(/APP_VERSION\s*=\s*'v?(\d{14})'/) || [])[1]; if (v) { cmVer = v; cmPath = c; break; } }
     }
     if (cmVer) {
       if (swVer === cmVer || swVer === 'v' + cmVer) ok(`cache SW == ${cmPath} (${swVer})`);
@@ -173,34 +188,29 @@ if (hasSwSection && swFile) {
       const vigLine = estado.split('\n').find((l) => /Cache version vigente|Versi[oó]n.*Cache/i.test(l)) || '';
       const vig = (vigLine.match(/`([^`]+)`/) || [])[1] || (vigLine.match(/v\d{14}/) || [])[0] || null;
       if (vig) {
-        const norm = (s) => String(s).replace(/^v/, ''); // tolera el prefijo 'v' (05 lo escribe con v; el SW da dígitos)
-        if (norm(vig) === norm(swVer)) ok(`05 cache vigente == SW ("${swVer}")`);
-        else warn(`05 STALE: declara cache vigente "${vig}" pero SW="${swVer}" → actualizar 05`);
-      } else {
-        info('05 no declara una "Cache version vigente" parseable (token en backticks)');
-      }
+        const nv = (s) => String(s).replace(/^v/, '');
+        if (nv(vig) === nv(swVer)) ok(`05 cache vigente == SW ("${swVer}")`);
+        else warn(`05 STALE: declara "${vig}" pero SW="${swVer}" → actualizar 05`);
+      } else info('05 sin "Cache version vigente" parseable');
     }
   }
-} else {
-  info('proyecto sin service-worker (o sin §4 en CLAUDE.md) — chequeos de cache omitidos');
-}
+} else head('  ℹ️  sin service-worker o sin §4 — omitido');
+if (BOOT && swFile) say('  ✅ cache verificada (SW↔manager↔05)');
 
-// 5) Referencias cruzadas. 5a/5b LEEN 99/30 (caros) → solo --full. 5c barato → siempre.
-console.log('\n5) Referencias cruzadas (huecos en el cerebro):');
+// 5) Referencias cruzadas
+head('\n5) Referencias cruzadas (huecos en el cerebro):');
 if (!BOOT && existsSync(histPath) && existsSync(indicePath)) {
-  // 5a) Todo ADR "## NN." de 99 debe tener fila "| §NN |" en 00-INDICE
   const histText = read(histPath);
   const indiceText = read(indicePath);
   const adrNums = new Set([...histText.matchAll(/^##\s+(\d+)\./gm)].map((m) => m[1]));
   const idxNums = new Set([...indiceText.matchAll(/^\|\s*§(\d+)\b/gm)].map((m) => m[1]));
   const missingIdx = [...adrNums].filter((n) => !idxNums.has(n)).sort((a, b) => +a - +b);
-  if (!adrNums.size) info('99 usa headers por fecha (no "## NN.") — chequeo 5a omitido');
+  if (!adrNums.size) info('99 con headers por fecha — 5a omitido');
   else if (!missingIdx.length) ok(`${adrNums.size} ADRs de 99 indexados en 00`);
   else warn(`${missingIdx.length} ADR(s) de 99 SIN fila en 00-INDICE: §${missingIdx.join(', §')}`);
 }
 const leccionesPath = join(DOCS, '30-LECCIONES.md');
 if (!BOOT && existsSync(leccionesPath)) {
-  // 5b) Referencias L-/M- usadas en el cerebro deben estar definidas (### L-NN/M-NN) en 30
   const leccionesText = read(leccionesPath);
   const cortoPath = join(DOCS, '10-MEMORIA-CORTO-PLAZO.md');
   const espacialPath = join(DOCS, '20-MEMORIA-ESPACIAL.md');
@@ -208,34 +218,28 @@ if (!BOOT && existsSync(leccionesPath)) {
   const histText = existsSync(histPath) ? read(histPath) : '';
   const indiceText = existsSync(indicePath) ? read(indicePath) : '';
   const defined = new Set([...leccionesText.matchAll(/^###\s+([LM]-\d{2})\b/gm)].map((m) => m[1]));
-  const allBrain = [
-    claude, indiceText,
-    existsSync(estadoPath) ? read(estadoPath) : '',
-    leccionesText, histText,
-    existsSync(cortoPath) ? read(cortoPath) : '',
-    existsSync(espacialPath) ? read(espacialPath) : '',
-  ].join('\n');
+  const allBrain = [claude, indiceText, existsSync(estadoPath) ? read(estadoPath) : '', leccionesText, histText,
+    existsSync(cortoPath) ? read(cortoPath) : '', existsSync(espacialPath) ? read(espacialPath) : ''].join('\n');
   const referenced = new Set([...allBrain.matchAll(/\b([LM]-\d{2})\b/g)].map((m) => m[1]));
   const dangling = [...referenced].filter((r) => !defined.has(r)).sort();
-  if (!referenced.size) info('aún no hay refs L-NN/M-NN en el cerebro');
-  else if (!dangling.length) ok(`refs L-/M- (${referenced.size} usadas / ${defined.size} def) todas resuelven en 30`);
-  else warn(`refs L-/M- COLGANTES (sin def en 30): ${dangling.join(', ')} → definir o corregir`);
+  if (!referenced.size) info('sin refs L-NN/M-NN aún');
+  else if (!dangling.length) ok(`refs L-/M- (${referenced.size} usadas / ${defined.size} def) resuelven en 30`);
+  else warn(`refs L-/M- COLGANTES: ${dangling.join(', ')}`);
 }
-if (BOOT) console.log('  ⏭️  5a/5b (ADRs↔índice, refs L-/M-) omitidas en --boot (leen 99/30) → pre-commit / brain:check');
-// 5c) Hojas docs/*.md referenciadas en CLAUDE.md deben existir — barato, siempre.
+if (BOOT) head('  ⏭️  5a/5b omitidas en --boot');
 const refDocs = new Set([...claude.matchAll(/docs\/([\w-]+\.md)/g)].map((m) => m[1]));
 const PLACEHOLDER = /^NN-|NOMBRE|<tema>|<carpeta>/;
 const missingDocs = [...refDocs].filter((f) => !PLACEHOLDER.test(f) && !existsSync(join(DOCS, f)));
 if (!missingDocs.length) ok(`hojas docs/*.md referenciadas en CLAUDE.md (${refDocs.size}) existen`);
 else warn(`hojas referenciadas en CLAUDE.md INEXISTENTES: ${missingDocs.join(', ')}`);
+if (BOOT && !missingDocs.length) say(`  ✅ ${refDocs.size} hojas referenciadas existen`);
 
-// 6) Skills del repo catalogadas en skills-inventory (lee N×SKILL.md) — solo --full.
-console.log('\n6) Skills del repo catalogadas en skills-inventory:');
+// 6) Skills ↔ inventario [--full] (v1.1: skills/ sin inventario = WARN)
+head('\n6) Skills del repo catalogadas en skills-inventory:');
 const SKILLS_DIR = join(ROOT, 'skills');
 const invPath = join(DOCS, 'skills-inventory.md');
-if (BOOT) {
-  console.log('  ⏭️  omitido en --boot (lee N×SKILL.md) → corre en pre-commit / npm run brain:check');
-} else if (existsSync(SKILLS_DIR) && existsSync(invPath)) {
+if (BOOT) head('  ⏭️  omitido en --boot');
+else if (existsSync(SKILLS_DIR) && existsSync(invPath)) {
   const inv = read(invPath);
   const grabName = (p) => { const m = read(p).match(/^[ \t]*name:[ \t]*["']?([^"'\n]+)/im); return m ? m[1].trim() : null; };
   const dirs = readdirSync(SKILLS_DIR, { withFileTypes: true }).filter((d) => d.isDirectory());
@@ -251,18 +255,202 @@ if (BOOT) {
           const p = join(SKILLS_DIR, d.name, sub.name, 'SKILL.md');
           if (existsSync(p)) { const n = grabName(p); if (n) names.push(n); }
         }
-      } catch { /* sin permiso/illegible: se cataloga por nombre de carpeta */ }
+      } catch { /* ilegible → por nombre de carpeta */ }
     }
     const catalogued = inv.includes(d.name) || names.some((n) => inv.includes(n));
-    if (!catalogued) { warn(`skill '${d.name}'${names.length ? ' (' + names.join(', ') + ')' : ''} NO está en skills-inventory.md → catalogar (§G.4)`); uncat++; }
+    if (!catalogued) { warn(`skill '${d.name}' NO está en skills-inventory.md → catalogar (§G.4)`); uncat++; }
   }
-  if (!uncat) ok(`${dirs.length} carpetas de skills/ catalogadas en skills-inventory.md`);
+  if (!uncat) ok(`${dirs.length} carpetas de skills/ catalogadas`);
+  // 6b) bidireccional: refs a skills inexistentes en el registry de lóbulos
+  const skillSet = new Set(dirs.map((d) => d.name));
+  const lobeSkillRefs = [...lobeRegistry.matchAll(/`([a-z][a-z0-9-]{3,})`/g)].map((m) => m[1])
+    .filter((s) => /-/.test(s) && !s.includes('.') && !s.includes('/'));
+  const ghost = [...new Set(lobeSkillRefs)].filter((s) => !skillSet.has(s) && !lobeRegistry.includes(`\`${s}\` (la skill`) && !lobeRegistry.includes(`(\`${s}\` retirada`));
+  if (ghost.length) info(`refs de skills en 40-LOBULOS que NO están en skills/ (verificar si son globales o fantasma): ${ghost.slice(0, 6).join(', ')}${ghost.length > 6 ? '…' : ''}`);
 } else if (existsSync(SKILLS_DIR)) {
-  // skills/ SIN catálogo = invisibles para el cerebro → problema real, no nota (ADR §173 / kernel v1.1)
   warn('skills/ existe pero docs/skills-inventory.md NO → crear el catálogo (§G.4)');
-} else {
-  info('skills/ no existe — chequeo de catálogo de skills omitido');
+} else head('  ℹ️  skills/ no existe — omitido');
+
+// 7) Integridad de archiveDir (deliberaciones) [--full]
+head('\n7) Integridad de archiveDir (deliberación capturada ↔ conectada):');
+const archiveDir = manifest.archiveDir ? join(ROOT, manifest.archiveDir) : null;
+if (BOOT) head('  ⏭️  omitido en --boot');
+else if (!archiveDir) info('manifest sin archiveDir — gate omitido (declararlo, §G.4)');
+else if (!existsSync(archiveDir)) info(`archiveDir no existe en esta máquina (${manifest.archiveDir}) — bóveda no clonada; gate omitido`);
+else {
+  const files = readdirSync(archiveDir).filter((f) => /\.(json|md)$/i.test(f) && !/^README/i.test(f) && f !== 'runs.log');
+  const readmePath = join(archiveDir, 'README.md');
+  const readme = existsSync(readmePath) ? read(readmePath) : '';
+  let bad = 0;
+  if (!readme) { warn('archiveDir sin README.md índice — todo crudo debe estar indexado'); bad++; }
+  else for (const f of files) if (!readme.includes(f)) { warn(`archivo de deliberación SIN fila en el README del archive: ${f}`); bad++; }
+  // anclas: toda ref "research-archive/<file>" en 99/00/10/specs debe resolver en archiveDir
+  const scanFiles = [histPath, indicePath, join(DOCS, '10-MEMORIA-CORTO-PLAZO.md')];
+  if (manifest.specsDir && existsSync(join(ROOT, manifest.specsDir)))
+    for (const s of readdirSync(join(ROOT, manifest.specsDir)).filter((f) => f.endsWith('.md')))
+      scanFiles.push(join(ROOT, manifest.specsDir, s));
+  const refd = new Set();
+  for (const sf of scanFiles) {
+    if (!existsSync(sf)) continue;
+    for (const m of read(sf).matchAll(/research-archive\/([\w][\w.-]+\.(?:json|md))/g)) refd.add(m[1]);
+  }
+  const danglingRefs = [...refd].filter((f) => !existsSync(join(archiveDir, f)));
+  if (danglingRefs.length) { warn(`anclas de deliberación que NO resuelven en archiveDir: ${danglingRefs.join(', ')}`); bad++; }
+  const runsLog = join(archiveDir, 'runs.log');
+  if (existsSync(runsLog)) {
+    for (const l of read(runsLog).split('\n').filter(Boolean)) {
+      const f = (l.split('|')[2] || '').trim();
+      if (f && f !== 'DESCARTADO' && !existsSync(join(archiveDir, f))) { warn(`runs.log cita archivo inexistente: ${f}`); bad++; }
+    }
+  }
+  if (!bad) ok(`archiveDir íntegro (${files.length} crudos indexados; anclas resuelven)`);
 }
 
-console.log(`\n${problems === 0 ? '✅ CEREBRO SANO' : '⚠️  ' + problems + ' problema(s) — revisar antes de avanzar'}\n`);
+// 8) SSoT — hecho duplicado fuera del nodo dueño [--full]
+head('\n8) SSoT (un hecho = un nodo dueño):');
+if (BOOT) head('  ⏭️  omitido en --boot');
+else if (!Array.isArray(manifest.ssotFacts) || !manifest.ssotFacts.length) info('manifest sin ssotFacts — gate omitido (declarar hechos críticos)');
+else {
+  let hits = 0;
+  for (const fact of manifest.ssotFacts) {
+    try {
+      const re = new RegExp(fact.regex, 'g');
+      for (const rel of fact.scan || []) {
+        if (rel === fact.owner) continue;
+        const p = join(ROOT, rel);
+        if (!existsSync(p)) continue;
+        const m = read(p).match(re);
+        if (m) { warn(`SSoT: "${fact.regex}" (dueño: ${fact.owner}) aparece en ${rel} (${m.length}×) → reemplazar por puntero`); hits++; }
+      }
+    } catch { warn(`ssotFacts: regex inválida "${fact.regex}"`); hits++; }
+  }
+  if (!hits) ok(`${manifest.ssotFacts.length} hecho(s) SSoT sin duplicados fuera de su dueño`);
+}
+
+// 9) Consolidado-aún-en-10 (síntoma exacto de la inflación) [--full]
+head('\n9) Consolidado-aún-en-10 (GC pendiente):');
+const cortoP = join(DOCS, '10-MEMORIA-CORTO-PLAZO.md');
+if (BOOT) head('  ⏭️  omitido en --boot');
+else if (existsSync(cortoP) && existsSync(indicePath)) {
+  const idxNums = new Set([...read(indicePath).matchAll(/^\|\s*§(\d+)\b/gm)].map((m) => m[1]));
+  let flagged = 0;
+  for (const l of read(cortoP).split('\n')) {
+    if (!l.trim().startsWith('|')) continue; // solo filas de tabla (TODO ledger)
+    // el ✅ debe estar en la CELDA de estado (no inline en el texto del item) — anti falso-positivo
+    const cells = l.split('|').map((c) => c.trim());
+    if (!cells.some((c) => /^✅/.test(c))) continue;
+    const secs = [...l.matchAll(/§(\d+)/g)].map((m) => m[1]);
+    if (secs.some((s) => idxNums.has(s))) { warn(`fila con estado ✅ ya consolidada (§${secs.join(',§')}) sigue en la tabla del 10 → retirarla en la poda (GC §G.4)`); flagged++; }
+  }
+  if (!flagged) ok('tabla TODO del 10 sin filas ✅ ya consolidadas');
+}
+
+// 10) BFS huérfanas de 2º orden (grafo de ruteo) [--full]
+head('\n10) Huérfanas de 2º orden (alcanzables desde los nodos de ruteo):');
+if (BOOT) head('  ⏭️  omitido en --boot');
+else {
+  const allow = new Set(manifest.orphanAllowlist || []);
+  const universe = readdirSync(DOCS).filter((f) => f.endsWith('.md'));
+  const edgeRe = /(?:docs\/)?([\w][\w-]*\.md)/g;
+  const fileText = (f) => existsSync(join(DOCS, f)) ? read(join(DOCS, f)) : '';
+  const reachable = new Set();
+  const queue = [];
+  // raíces: CLAUDE.md + 00 + 40 (sus referencias arrancan el grafo)
+  for (const rootTxt of [claude, fileText('00-INDICE.md'), fileText('40-LOBULOS-DOMINIO.md')])
+    for (const m of rootTxt.matchAll(edgeRe)) if (universe.includes(m[1]) && !reachable.has(m[1])) { reachable.add(m[1]); queue.push(m[1]); }
+  reachable.add('00-INDICE.md'); reachable.add('40-LOBULOS-DOMINIO.md');
+  while (queue.length) {
+    const cur = queue.pop();
+    for (const m of fileText(cur).matchAll(edgeRe)) if (universe.includes(m[1]) && !reachable.has(m[1])) { reachable.add(m[1]); queue.push(m[1]); }
+  }
+  const orphans = universe.filter((f) => !reachable.has(f) && !allow.has(f));
+  if (!orphans.length) ok(`${universe.length} docs de docs/ alcanzables desde el grafo de ruteo`);
+  else warn(`huérfanas de 2º ORDEN (existen pero ningún nodo de ruteo llega a ellas): ${orphans.join(', ')} → conectar o allowlist con razón`);
+}
+
+// 11) Peer-hash del kernel ×N repos [--full]
+head('\n11) Peer-hash del kernel (byte-identidad ×repos):');
+if (BOOT) head('  ⏭️  omitido en --boot');
+else if (!Array.isArray(manifest.peers) || !manifest.peers.length) info('manifest sin peers — gate omitido');
+else {
+  const kernelFiles = manifest.kernelFiles || ['scripts/brain-check.mjs'];
+  let divergent = 0, absent = 0;
+  for (const peer of manifest.peers) {
+    const peerRoot = join(ROOT, peer);
+    if (!existsSync(peerRoot)) { absent++; continue; }
+    for (const kf of kernelFiles) {
+      const a = join(ROOT, kf), b = join(peerRoot, kf);
+      if (!existsSync(a) || !existsSync(b)) { info(`peer ${peer}: ${kf} ausente en un lado`); continue; }
+      if (sha(read(a)) !== sha(read(b))) { warn(`KERNEL DIVERGENTE: ${kf} difiere vs ${peer} → re-propagar desde el canon (Copy-Item + Get-FileHash)`); divergent++; }
+    }
+  }
+  if (absent) info(`${absent} peer(s) no clonado(s) en esta máquina — omitidos`);
+  if (!divergent) ok(`kernel byte-idéntico con los peers presentes (${(manifest.kernelFiles || []).join(', ') || 'brain-check.mjs'})`);
+}
+
+// 12) Fechas stale en 05/10 [info · corre también en --boot]
+{
+  const staleDays = manifest.staleDays || 10;
+  const today = new Date();
+  let oldest = null, oldestWhere = '';
+  for (const rel of ['docs/05-ESTADO-GLOBAL.md', 'docs/10-MEMORIA-CORTO-PLAZO.md']) {
+    const p = join(ROOT, rel);
+    if (!existsSync(p)) continue;
+    const m = read(p).match(/(?:última actualización[:* ]*|\(al |actualizado )\**(\d{4}-\d{2}-\d{2})/i);
+    if (m) { const d = new Date(m[1]); if (!oldest || d < oldest) { oldest = d; oldestWhere = rel; } }
+  }
+  if (oldest) {
+    const days = Math.floor((today - oldest) / 86400000);
+    if (days > staleDays) info(`frescura: ${oldestWhere} sellado hace ${days} días (> ${staleDays}) → re-verificar vs git real y re-sellar`);
+  }
+}
+
+// 13) Specs: checklist con evidencia [--full]
+head('\n13) Specs con checklist tickeable (evidencia, no dibujito):');
+if (BOOT) head('  ⏭️  omitido en --boot');
+else if (!manifest.specsDir) info('manifest sin specsDir — gate omitido');
+else {
+  const sd = join(ROOT, manifest.specsDir);
+  if (!existsSync(sd)) info(`specsDir no existe (${manifest.specsDir})`);
+  else {
+    const specs = readdirSync(sd).filter((f) => f.endsWith('.md'));
+    let noCk = 0, badTicks = 0;
+    const EVIDENCE = /§\d+|TODO-\d+|commit|`[^`]+`|docs\/|research-archive\/|https?:\/\/|SHA|hash|\d{4}-\d{2}-\d{2}/i;
+    for (const s of specs) {
+      const t = read(join(sd, s));
+      if (!/^##+\s*.*Checklist/im.test(t)) { noCk++; continue; }
+      for (const l of t.split('\n')) {
+        if (!/^\s*-\s*\[x\]/i.test(l)) continue;
+        if (!EVIDENCE.test(l)) { warn(`${s}: ítem tickeado SIN evidencia resoluble: "${l.trim().slice(0, 70)}…"`); badTicks++; }
+      }
+    }
+    if (!badTicks) ok(`ticks de checklist con evidencia en ${specs.length - noCk} spec(s) con checklist`);
+    if (noCk) info(`${noCk} spec(s) sin sección "## Checklist" (los previos a la convención §173 — info)`);
+  }
+}
+
+// 14) deepAudit — auditoría Nivel-2 vigente [nudge info; días en --boot, headers solo en --full]
+{
+  const da = manifest.deepAudit;
+  if (da && da.last) {
+    const days = Math.floor((new Date() - new Date(da.last)) / 86400000);
+    let due = da.maxDays && days > da.maxDays ? `hace ${days} días (> ${da.maxDays})` : null;
+    if (!BOOT && da.maxAdrGap && existsSync(histPath)) {
+      const headers = (read(histPath).match(/^##\s+/gm) || []).length;
+      if (da.coveredHeaderCount && headers - da.coveredHeaderCount >= da.maxAdrGap)
+        due = (due ? due + ' y ' : '') + `${headers - da.coveredHeaderCount} ADRs nuevos (≥ ${da.maxAdrGap})`;
+    }
+    if (due) info(`🔬 auditoría Nivel-2 VENCIDA: última ${da.last}, ${due} → correr skill auditoria-cerebro (§173)`);
+  } else info('manifest sin deepAudit — la auditoría Nivel-2 no tiene disparador (declararlo, §173)');
+}
+
+// ---- salida (presupuesto de stdout en --boot) ----
+lines.push(`\n${problems === 0 ? '✅ CEREBRO SANO (estructura íntegra' + (manifest.deepAudit && manifest.deepAudit.last ? ' · auditoría semántica: ' + manifest.deepAudit.last : '') + ')' : '⚠️  ' + problems + ' problema(s) — revisar antes de avanzar'}\n`);
+let out = lines;
+if (BOOT && out.join('\n').length > 2000) {
+  // presupuesto duro: cada línea del boot se re-inyecta como contexto en CADA sesión
+  out = out.filter((l) => !l.startsWith('  ✅') || /BOOT|SANO/.test(l));
+  if (out.join('\n').length > 2000) out = out.slice(0, 24).concat(['  … (recortado por presupuesto de stdout; detalle: npm run brain:check)']);
+}
+console.log(out.join('\n'));
 process.exit(problems ? 1 : 0);

--- a/scripts/brain-diff.mjs
+++ b/scripts/brain-diff.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+// ===========================================================
+// 🧠 brain-diff — Inventario federado de cerebros (KERNEL · 2º archivo · MANUAL)
+// ===========================================================
+// Escanea la carpeta PADRE (ROOT/..) buscando repos git y reporta el estado del
+// cerebro de cada uno: ¿tiene CLAUDE.md? ¿marcador de versión del template?
+// ¿manifest? ¿kernel byte-idéntico al de ESTE repo?
+//
+// ⚠️ NUNCA va en SessionStart ni en --boot (inventario federado ≠ salud local;
+//    ROOT/.. en otra máquina puede ser cualquier cosa — ADR §173).
+//    Uso: npm run brain:diff (manual, p.ej. al sospechar drift o al crear un repo).
+//
+// La detección TERMINA en una fila TODO accionable (impresa al final), no en
+// stdout que nadie persiste. ignoreDirs en docs/.brain-manifest.json.
+// ===========================================================
+import { readFileSync, readdirSync, existsSync, statSync } from 'fs';
+import { join, dirname, basename } from 'path';
+import { fileURLToPath } from 'url';
+import { createHash } from 'crypto';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const PARENT = join(ROOT, '..');
+const read = (p) => readFileSync(p, 'utf-8');
+const sha = (s) => createHash('sha256').update(s.replace(/\r\n/g, '\n')).digest('hex');
+
+let manifest = {};
+const mp = join(ROOT, 'docs', '.brain-manifest.json');
+if (existsSync(mp)) { try { manifest = JSON.parse(read(mp)); } catch { /* defaults */ } }
+const IGNORE = new Set([...(manifest.ignoreDirs || []), 'brain-private', 'node_modules']);
+
+const myKernel = join(ROOT, 'scripts', 'brain-check.mjs');
+const myHash = existsSync(myKernel) ? sha(read(myKernel)) : null;
+const me = basename(ROOT);
+
+console.log(`\n🧠 BRAIN-DIFF — inventario de cerebros en ${PARENT}\n   (referencia de kernel: ${me} → ${myHash ? myHash.slice(0, 12) + '…' : 'SIN brain-check.mjs'})\n`);
+
+const todos = [];
+const dirs = readdirSync(PARENT, { withFileTypes: true })
+  .filter((d) => d.isDirectory() && !d.name.startsWith('.') && !IGNORE.has(d.name));
+
+for (const d of dirs) {
+  const repo = join(PARENT, d.name);
+  if (!existsSync(join(repo, '.git'))) continue; // solo repos git
+  const claudeP = join(repo, 'CLAUDE.md');
+  const hasClaude = existsSync(claudeP);
+  let version = '—';
+  if (hasClaude) {
+    const first = read(claudeP).split('\n')[0];
+    version = (first.match(/brain-template-version:\s*([\d.]+)/) || [])[1] || 'SIN marcador';
+  }
+  const kp = join(repo, 'scripts', 'brain-check.mjs');
+  const kernel = existsSync(kp) ? (myHash && sha(read(kp)) === myHash ? '✅ idéntico' : '⚠️ DIVERGE') : '—';
+  const hasManifest = existsSync(join(repo, 'docs', '.brain-manifest.json')) ? '✅' : '—';
+  const ignored = IGNORE.has(d.name) ? ' (ignoreDirs)' : '';
+  console.log(`  ${d.name}${d.name === me ? ' (este)' : ''}${ignored}`);
+  console.log(`     CLAUDE.md: ${hasClaude ? '✅' : '❌ SIN CEREBRO'} · template: ${version} · manifest: ${hasManifest} · kernel: ${kernel}`);
+
+  if (!hasClaude) todos.push(`| TODO-XX | 🧠 Repo \`${d.name}\` SIN cerebro → instalar con la receta \`INSTALACION-CEREBRO.md\` del canon (bersaglio) | 🔲 | decisión cliente |`);
+  else if (version === 'SIN marcador') todos.push(`| TODO-XX | 🧠 \`${d.name}\`: CLAUDE.md sin marcador de versión del template → añadir línea 1 | 🔲 | — |`);
+  if (kernel === '⚠️ DIVERGE') todos.push(`| TODO-XX | 🧠 \`${d.name}\`: kernel brain-check.mjs DIVERGE del de ${me} → re-propagar desde el canon | 🔲 | — |`);
+}
+
+if (todos.length) {
+  console.log('\n📋 Filas TODO accionables (copiar a la tabla del nodo 10 — la detección no vale si nadie la persiste):');
+  for (const t of todos) console.log('  ' + t);
+} else {
+  console.log('\n✅ Todos los repos git del directorio tienen cerebro con marcador y kernel consistente.');
+}
+console.log('');

--- a/skills/auditoria-cerebro/SKILL.md
+++ b/skills/auditoria-cerebro/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: auditoria-cerebro
+description: Auditoría profunda Nivel-2 del cerebro documental del proyecto activo — lo que el linter estructural NO puede medir (fidelidad, frescura, función). Sondas FALSABLES sin puntaje numérico; cierra con GC pareado (masa-neta ≤0) y actualiza deepAudit en el manifest. Disparo - cuando brain-check imprime "auditoría Nivel-2 VENCIDA", antes de exportar el template a un repo nuevo, o a pedido ("audita el cerebro").
+---
+
+# 🔬 Auditoría de Cerebro — Nivel 2 (semántica)
+
+> **Qué es**: el linter (`brain:check`) valida ESTRUCTURA (caps, huérfanas, refs). Esta skill valida
+> lo que ningún linter puede: **¿el contenido es verdad? ¿está fresco? ¿el cerebro FUNCIONA como
+> memoria?** Es la 2ª mitad del criterio "SANO" (evaluación de 2 niveles).
+> **Anti-score-teatro**: SIN puntaje numérico (un score LLM no es reproducible). Cada sonda es
+> FALSABLE: produce hallazgos con evidencia `archivo:línea` + comando de verificación, o pasa.
+> **KPIs del lazo**: hallazgos REINCIDENTES (vs auditoría anterior) + tasa de re-investigación.
+
+## Protocolo (en orden; cada sonda = subagente o verificación directa)
+
+### Sonda 0 — Diff vs auditoría anterior (SIEMPRE primero)
+Localiza la tabla de hallazgos de la auditoría anterior (en el `archiveDir` del manifest).
+Para cada hallazgo previo: ¿cerrado con evidencia, abierto-tracked, o REINCIDENTE?
+**Reincidente = regresión del lazo → meta-lección M-NN obligatoria en el nodo de lecciones.**
+
+### Sonda 1 — Fidelidad de estado (la clase "App-Check ×3 estados")
+Toma 3-5 hechos de estado declarados en los nodos always-on (05/10): versión desplegada, qué está
+LIVE, branch, gates. Verifícalos contra la realidad (git log/origin, archivos, consola si aplica).
+Cualquier contradicción entre nodos o vs la realidad = hallazgo (cita ambas fuentes).
+
+### Sonda 2 — Frescura honesta
+¿Los sellos de fecha de 05/10 reflejan su contenido? ¿Hay afirmaciones que caducan solas
+("en sync con main", "X pendiente" ya hecho)? Contrasta vs `git log` real de los últimos días.
+
+### Sonda 3 — RETRIEVAL-DRILL (la función, no el almacén) ⭐
+Lanza un subagente FRÍO (sin este contexto) con SOLO el boot del proyecto (CLAUDE.md + 05 + 10) y
+3-5 preguntas canónicas extraídas de casos REALES de re-investigación pasada (no del índice — eso
+sería teatro de función). Ej.: "¿dónde vive X?", "¿por qué se decidió Y?", "¿qué NO debes reintentar?".
+Mide: ¿llegó a la neurona correcta? ¿en cuántos saltos? ¿cuánto contexto quemó? Falla de retrieval
+= hallazgo de ruteo (el conocimiento existe pero el cerebro no lo ENTREGA).
+
+### Sonda 4 — Captura de deliberación (fidelidad, no presencia)
+El linter (check #7) valida PRESENCIA. Tú validas FIDELIDAD: toma la última síntesis de deliberación
+y pregunta: *¿una sesión fresca re-tomaría la MISMA decisión leyendo SOLO la síntesis?* ¿Los
+"callejones probados" están? ¿Lo refutado tiene su porqué?
+
+### Sonda 5 — Consistencia de la memoria del harness (MEMORY.md)
+Si el harness mantiene una memoria propia (MEMORY.md / memoria de usuario): ¿APUNTA al cerebro o
+DUPLICA estado? (regla SSoT). ¿Contradice algún nodo? Duplicación = hallazgo.
+
+### Sonda 6 — Economía y caps
+¿El boot creció desde la última auditoría? ¿Hay neuronas ≥90% sin plan de shard? ¿Texto narrativo
+en el 10 que ya es ADR? (El linter da números; tú juzgas si el CONTENIDO que queda merece estar.)
+
+### Sonda 7 — Voz adversarial (riesgos no estimados)
+Un subagente pregunta: "¿qué falla de este cerebro NO está cubierta por ninguna sonda ni gate?"
+Lo que encuentre alimenta la próxima versión de esta skill (anti-engorde: también propone QUITAR
+gates que no cazaron nada en 2 auditorías).
+
+## Cierre (obligatorio — la auditoría que no cierra es teatro)
+
+1. **Tabla de hallazgos** máquina-legible (ID | severidad | categoría | hallazgo | evidencia | estado)
+   → al `archiveDir` del manifest + fila en su README.
+2. **Síntesis** como ADR en el historial del repo (+ fila en el índice), con línea-ancla `Deliberación:`.
+3. **GC pareado (masa-neta)**: toda auditoría cierra con una poda equivalente — el delta de chars
+   del boot tras la auditoría debe ser ≤ 0, o la auditoría está INCOMPLETA.
+4. **Actualizar `deepAudit` en `docs/.brain-manifest.json`**: `last` = hoy, `coveredHeaderCount` =
+   número actual de headers `## ` en el historial. (Esto apaga el nudge del linter — y es lo que
+   hace al disparador auto-vigilado: si no lo actualizas, el nudge sigue encendido.)
+5. Hallazgos accionables → filas TODO-NN en el nodo 10 (ledger único). NO crear docs de estado nuevos.
+
+## Modo sin-tokens (fallback)
+Sin presupuesto para subagentes: corre las sondas 0-2 y 6 tú mismo (verificación directa), marca
+3-5 como `[PENDIENTE: requiere subagentes]` en la tabla, y actualiza deepAudit igual — una
+auditoría parcial HONESTA vale más que una completa fingida.

--- a/skills/comite-expertos/SKILL.md
+++ b/skills/comite-expertos/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: comite-expertos
-description: "Monta un comité de expertos que MEJORA ×3 la última respuesta de Claude. Infiere SOLO qué expertos convienen según el tema (no son fijos), los hace criticar y debatir entre ellos, y un 'presidente' sintetiza una versión mejor en 3 rondas. En decisiones caras de revertir, suma una 2ª opinión externa (Gemini, vía docs/15-CONSEJO-EXTERNO.md). GATILLOS OBLIGATORIOS (dispara sí o sí): 'monta el comité', 'comité de expertos', 'mejora esto x3', 'mejórala x3', 'aplícale el comité', 'pásale el comité', 'tribunal de expertos', 'que debatan esto', 'mejora tu respuesta', 'mejora la respuesta anterior', 'puedes mejorar esa respuesta'. GATILLOS de niveles ligeros: 'mejórala un poco' (1 ronda), 'piensa críticamente y asume que cometiste un error' (auto-crítica honesta). Úsala SIEMPRE que el usuario pida mejorar, criticar, pulir o profundizar una respuesta ya dada, o cuando una respuesta importante merezca un segundo par de ojos antes de actuar. NO disparar para datos triviales de un solo dato correcto, ni para tareas puramente mecánicas."
+description: "Monta un comité de expertos que MEJORA ×3 la última respuesta de Claude. Infiere SOLO qué expertos convienen según el tema (no son fijos), los hace criticar y debatir, y un presidente sintetiza una versión mejor en 3 rondas. En decisiones caras de revertir, suma 2ª opinión externa (provider configurado en docs/15-CONSEJO-EXTERNO.md). GATILLOS OBLIGATORIOS: monta el comité, comité de expertos, mejora esto x3, mejórala x3, aplícale el comité, pásale el comité, tribunal de expertos, que debatan esto, mejora tu respuesta, mejora la respuesta anterior, puedes mejorar esa respuesta. GATILLOS ligeros: mejórala un poco (1 ronda), piensa críticamente y asume que cometiste un error (auto-crítica). Úsala SIEMPRE que pidan mejorar/criticar/pulir/profundizar una respuesta ya dada, o cuando una respuesta importante merezca segundo par de ojos. NO disparar para datos triviales ni tareas mecánicas."
 ---
 
 # 🧠 Comité de Expertos — mejora ×3 de una respuesta
@@ -96,10 +96,10 @@ Si una ronda no produce mejora real (el comité converge antes de la 3ª), dilo 
 
 Si el tema es una **Decisión Fuerte** (arquitectura/modelo de datos, seguridad/legal, operación
 irreversible, fork 50/50 — ver criterios en `docs/15-CONSEJO-EXTERNO.md §2`):
-1. Tras el comité interno, **prepara un prompt autocontenido** para el proveedor externo (Gemini,
+1. Tras el comité interno, **prepara un prompt autocontenido** para el proveedor externo configurado (ver docs/15,
    `docs/15-CONSEJO-EXTERNO.md §0` y §4) — el modelo externo no ve nuestro código ni el cerebro, todo
    el contexto va en el prompt. Aplica **anti-anclaje** (§4.2): en decisiones TOP no incluyas tu postura.
-2. **Pausa y entrégaselo al cliente** (humano en el medio): lo pega en Gemini y te trae la respuesta.
+2. **Pausa y entrégaselo al cliente** (humano en el medio): lo pega en el provider externo y te trae la respuesta.
 3. Integra esa respuesta como **un peer review más**: adopta lo correcto, **refuta con razones** lo que
    esté mal, y sintetiza. Nunca te subordines al modelo externo: es insumo, no oráculo.
 
@@ -112,7 +112,7 @@ Para temas rutinarios/reversibles, **omite el Paso 5** (el comité interno ×3 b
 1. **La respuesta mejorada** (es el producto principal — entrégala completa, lista para usar).
 2. **Qué mejoró y por qué** — 3–6 bullets: los cambios netos más importantes que introdujeron las
    rondas (idealmente uno por punto ciego tapado). Honesto: si algo de la respuesta original estaba mal, dilo.
-3. Si hubo 2ª opinión externa: 1 línea de qué aportó/cambió Gemini y qué refutaste.
+3. Si hubo 2ª opinión externa: 1 línea de qué aportó/cambió el provider externo y qué refutaste.
 
 ---
 

--- a/skills/legal-colombia/SKILL.md
+++ b/skills/legal-colombia/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: legal-colombia
-description: "Guardrail + método para CUALQUIER tarea legal de un negocio COLOMBIANO (e-commerce, joyería, datos personales). Garantiza que todo lo legal se haga en marco jurídico de COLOMBIA, con investigación profunda en fuentes oficiales (.gov.co), NUNCA con plugins extranjeros (legal:*, legalzoom:* son de EE.UU. y excluyen la ley no-estadounidense). GATILLOS OBLIGATORIOS: redactar/revisar términos y condiciones, política de privacidad / tratamiento de datos / habeas data, aviso de privacidad, política de cookies, política de devoluciones/garantías/retracto, política de envíos, contrato, 'es legal esto', cumplimiento normativo, derecho de retracto, garantía legal, reversión de pago, datos personales, Ley 1581, Ley 1480, SIC, RUCOM, lavado de activos / SARLAFT / SAGRILAFT, UIAF, factura electrónica, IVA, DIAN, registrar base de datos / RNBD. Dispara TAMBIÉN como guardrail si se va a usar un skill/plugin legal extranjero (legal:*, legalzoom:*, small-business:contract-review, legal:review-contract) para contenido del sitio o del negocio: DETENTE y usa este marco colombiano. NO disparar para temas legales de OTRO país explícitamente solicitados."
+description: "Guardrail + método para CUALQUIER tarea legal de un negocio COLOMBIANO (e-commerce, joyería, datos personales). Garantiza que todo lo legal se haga en marco jurídico de COLOMBIA, con investigación profunda en fuentes oficiales (.gov.co), NUNCA con plugins extranjeros. GATILLOS OBLIGATORIOS: redactar/revisar términos y condiciones, política de privacidad / tratamiento de datos / habeas data, aviso de privacidad, política de cookies, política de devoluciones/garantías/retracto, política de envíos, contrato, 'es legal esto', cumplimiento normativo, derecho de retracto, garantía legal, reversión de pago, datos personales, Ley 1581, Ley 1480, SIC, RUCOM, lavado de activos / SARLAFT / SAGRILAFT, UIAF, factura electrónica, IVA, DIAN, registrar base de datos / RNBD. Dispara TAMBIÉN como guardrail si se va a usar un skill/plugin legal extranjero para contenido del sitio o del negocio: DETENTE y usa este marco colombiano. NO disparar para temas legales de OTRO país explícitamente solicitados."
 ---
 
 # ⚖️ Legal Colombia — guardrail + método
@@ -24,7 +24,7 @@ Usa este método. (Puedes usar esos plugins solo si el usuario pide EXPLÍCITAME
 ## 📚 Método (en orden)
 
 1. **Lee el lóbulo legal del proyecto PRIMERO** si existe (su número varía por proyecto, p.ej.
-   `docs/42-LEGAL.md`): marco colombiano curado — Ley 1480, Ley 1581, RUCOM, SAGRILAFT, DIAN/IVA,
+   el lóbulo legal del proyecto, si existe): marco colombiano curado — Ley 1480, Ley 1581, RUCOM, SAGRILAFT, DIAN/IVA,
    páginas legales del sitio, TODOs `LEGAL-NN`. Si el proyecto no tiene lóbulo legal, ve directo al paso 2.
 2. **Investigación profunda con agentes/workflow** (directiva del cliente: *siempre, con workflows y
    agentes*). Para algo sustantivo (redactar una política, decidir cumplimiento, verificar un
@@ -34,11 +34,11 @@ Usa este método. (Puedes usar esos plugins solo si el usuario pide EXPLÍCITAME
    **anm.gov.co** (RUCOM/minerales). **Nunca** de memoria ni de plugins extranjeros. Marca lo no
    verificado como **[a verificar]**.
 3. **Produce SIEMPRE en marco colombiano**, citando la norma (Ley/Decreto Nº y año) + fuente oficial.
-4. **Disclaimer obligatorio** (de `docs/42-LEGAL.md §0`): esto es **orientación, NO asesoría legal**;
+4. **Disclaimer obligatorio** (del lóbulo legal del proyecto, si existe): esto es **orientación, NO asesoría legal**;
    antes de **publicar** texto legal o decidir cumplimiento, **validar con un abogado colombiano**.
 5. **Es Decisión Fuerte** (ver la doctrina de comité del proyecto + el nodo de Consejo Externo, p.ej. `docs/15-CONSEJO-EXTERNO.md`): redactar/decidir algo
-   legal sustantivo → activa **Comité ×3** + prepara **2ª opinión externa** (Gemini).
-6. **Captura** lo nuevo en `docs/42-LEGAL.md` (Reflejo de Frescura). Tarea legal grande cerrada →
+   legal sustantivo → activa **Comité ×3** + prepara **2ª opinión externa** (provider configurado, docs/15).
+6. **Captura** lo nuevo en el lóbulo legal del proyecto (Reflejo de Frescura; créalo si no existe — Trigger 🔵). Tarea legal grande cerrada →
    ADR en `99` + fila en `00-INDICE`.
 
 ---


### PR DESCRIPTION
… + bóveda (comité v6)

- Kernel v1.2 byte-idéntico ×3 (15 checks; gate #12 ya marcó este repo: 05 sellado hace 33 días → re-verificación = ítem T del checklist v6, sesión propia) + scripts/brain-diff.mjs + npm script.
- Skill auditoria-cerebro (Nivel-2: sondas falsables + retrieval-drill + deepAudit) + comité/legal descontaminadas (<1024). Catalogadas en skills-inventory.
- archiveDir → bóveda privada ../brain-private/altorrainmobiliaria/ (stub público con puntero).
- Marcador brain-template-version: 1.1.0 + reglas PROPIEDAD/ADMISIÓN en §G + manifest con peers/kernelFiles/deepAudit/staleDays.
- Checklist completo → specs/2026-06-09-comite-v6-…VEREDICTO.md en cars.