### PR TITLE
docs(cerebro): [OPUS-4.8] harmonizacion cross-repo - activar gate SSo…

### DIFF
--- a/docs/.brain-manifest.json
+++ b/docs/.brain-manifest.json
@@ -44,13 +44,20 @@
     "scripts/brain-check.mjs",
     "scripts/brain-diff.mjs"
   ],
-  "ignoreDirs": [
-    "bersaglio-design"
-  ],
   "orphanAllowlist": [],
   "peers": [
     "../altorracars.github.io",
     "../bersagliojewelry.github.io"
+  ],
+  "ssotFacts": [
+    {
+      "regex": "altorra-pwa-v\\d+",
+      "owner": "docs/05-ESTADO-GLOBAL.md",
+      "scan": [
+        "docs/10-MEMORIA-CORTO-PLAZO.md"
+      ],
+      "_que": "version de cache PWA: vive SOLO en 05 (activa el gate SSoT, antes inerte - harmonizacion cross-repo, cf. bersaglio H-06 / cars §207)"
+    }
   ],
   "deepAudit": {
     "last": "2026-06-09",


### PR DESCRIPTION
…T inerte + quitar ignoreDirs

Coordinacion ×3 desde la sesion de cars. (1) ssotFacts estaba AUSENTE -> gate SSoT #8 inerte (la causa raiz H-06 de la auditoria de bersaglio, nunca aplicada al rezagado): poblado con la version de cache PWA (owner 05, scan 10), 10 verificado limpio. (2) ignoreDirs fantasma fuera. brain:check SANO, gate SSoT ahora vivo. Kernel intacto. Inmobiliaria aun necesita su Nivel-2 (T).

Modelo: Opus 4.8 - pendiente revision Fable 5 (no disponible).