### PR TITLE
docs(gobernanza): consejero externo (Antigravity/Gemini) NUNCA edita …

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,7 @@ Al iniciar una conversación nueva estás **estrictamente obligado** a leer SOLO
 - **🧪 Experiencia**: ANTES de op riesgosa/repetitiva (deploy CF, mover archivos, tocar SW/caché/reglas) → **Memoria Procedimental** (`30`). Si un síntoma "te suena", ahí está la receta.
 - **🟢 Historia**: "por qué" de una decisión o detalle de un § → Índice → Largo Plazo.
 - **🔵 Auditoría/Dominio**: análisis especializado (seguridad/legal/UX/SEO/perf) → (1) skill relevante; (2) `40-LOBULOS`; (3) neurogénesis del hijo con contenido REAL (§G.4); (4) capturar findings + qué skill usé.
-- **🛰️ Decisión Fuerte**: ANTES de algo caro de revertir (arquitectura/datos/seguridad/legal) considera crítica adversarial del provider externo (`15-CONSEJO-EXTERNO`). Sin provider → sigo solo + marco la decisión como NO revisada.
+- **🛰️ Decisión Fuerte**: ANTES de algo caro de revertir (arquitectura/datos/seguridad/legal) considera crítica adversarial del provider externo (**asesora, NUNCA edita; el comité + el provider DEBATEN, YO delibero/decido/implemento**) (`15-CONSEJO-EXTERNO`). Sin provider → sigo solo + marco la decisión como NO revisada.
 
 **Enrutamiento semántico**: ante una duda, NO escanees el cerebro. Ve al `docs/00-INDICE.md` (capa "síntoma → neurona").
 

--- a/docs/15-CONSEJO-EXTERNO.md
+++ b/docs/15-CONSEJO-EXTERNO.md
@@ -21,5 +21,6 @@
 4. **Integra** como un peer-review más: adopta lo correcto, refuta con razón lo que no, sintetiza. Insumo, no oráculo.
 
 ## §3 — Límites
+- 🚫 **El consejero externo (Gemini vía Antigravity) NUNCA edita el repo.** Es un IDE agéntico (PUEDE editar), pero aquí es de **SOLO-LECTURA**: recibe únicamente prompts de **CRÍTICA** (preguntas/hallazgos), JAMÁS tareas de implementación. **El comité interno ×3 + el consejero DEBATEN/aportan hallazgos; quien DELIBERA, DECIDE e IMPLEMENTA (edita/commitea/pushea) es Claude** — ellos asesoran, yo resuelvo. (Aprendido en Altorra Cars 2026-06-19: un mensaje de implementación suelto que se pega en Antigravity le abre la puerta a editar en paralelo → colisión; cerrar el ciclo end-to-end uno mismo lo evita.)
 - El modelo externo puede equivocarse (verifica sus afirmaciones contra el código, §3.3). No tiene memoria del proyecto.
 - Registra en el ADR qué aportó/cambió la 2ª opinión y qué refutaste.


### PR DESCRIPTION
…— solo asesora (§15 + §G.2)

Novedad de gobernanza del dueño (2026-06-19), propagada desde Altorra Cars: el provider/consejero externo es de SOLO-LECTURA. El comite interno + el consejero DEBATEN/aportan hallazgos; quien DELIBERA, DECIDE e IMPLEMENTA (edita/commitea/ pushea) es Claude. Antigravity es un IDE agentico que PUEDE editar, pero aqui solo recibe prompts de critica, jamas tareas de implementacion.

- docs/15 §3 (Limites): bullet explicito "NUNCA edita".
- CLAUDE.md §G.2 (always-on): "(asesora, NUNCA edita; YO delibero/decido/implemento)".


Modelo: Opus 4.8