### PR TITLE
feat(skills): propaga `spec-kit` — Spec-Driven Development portable +…

### DIFF
--- a/docs/skills-inventory.md
+++ b/docs/skills-inventory.md
@@ -39,6 +39,7 @@ de mis capacidades. Implicaciones:
 | Skill (name) | Carpeta (si difiere) | Para qué | Disp. |
 |---|---|---|---|
 | `brainstorming` | | Explorar intención/requisitos ANTES de construir | ✅ |
+| `spec-kit` | | **Spec-Driven Development** (método GitHub spec-kit, MIT): idea→spec→clarify→plan→tasks→analyze→implement con [NEEDS CLARIFICATION]+constitución+test-first. Plantillas en `references/` + subagentes `spec-analyze`/`plan-auditor`. Para features NUEVAS no triviales. Global+repo (2026-06-25). | ✅ |
 | `writing-plans` | | Escribir plan de implementación multi-paso | ✅ |
 | `executing-plans` | | Ejecutar un plan con checkpoints de revisión | ✅ |
 | `subagent-driven-development` | | Ejecutar plan con subagentes en la sesión | ✅ |

--- a/skills/spec-kit/SKILL.md
+++ b/skills/spec-kit/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: spec-kit
+description: Spec-Driven Development (SDD) — el método de GitHub spec-kit para construir software CON IA con rigor. Úsalo ANTES de codear una funcionalidad o proyecto NUEVO no trivial: convierte una idea vaga en spec ejecutable → plan técnico → tareas ordenadas → implementación verificable, en vez de saltar directo a código. El flujo de 7 fases (constitution → specify → clarify → plan → tasks → analyze → implement) separa el QUÉ/POR-QUÉ (spec, estable, sin tecnología) del CÓMO (plan, tecnología+arquitectura) de las TAREAS (unidades ejecutables [P]-paralelizables), marca lo ambiguo con [NEEDS CLARIFICATION] (no adivinar), y mete gates de constitución (test-first, simplicidad, anti-abstracción). Triggers — "armemos una spec", "spec-driven", "planeemos bien esta feature antes de codear", "convierte este requerimiento en plan/tareas", "constitution del proyecto", "quiero specs ejecutables", construir algo nuevo desde cero con calidad. NO uses para: fixes triviales, ediciones de una línea, hacking exploratorio, o depurar un bug ya reproducible (eso es systematic-debugging). Portable: cero rutas de un repo; adapta al stack del proyecto activo.
+---
+
+# 🧭 Spec-Kit — Spec-Driven Development (SDD)
+
+> Port portable del método **GitHub spec-kit** (https://github.com/github/spec-kit, MIT).
+> spec-kit normalmente instala slash-commands `/speckit.*` + plantillas vía el CLI `specify`.
+> Esta skill captura el MÉTODO y las PLANTILLAS para ejecutarlo en cualquier proyecto sin el CLI.
+> Plantillas verbatim-adaptadas → `references/`. Cuándo escalar y cómo, abajo.
+
+## 0. La inversión (por qué importa)
+**El código sirve a la spec, no al revés.** En SDD la spec en lenguaje natural es la *fuente de
+verdad*; el código es la "última milla" generada. Mantener: *Maintenance = evolucionar la spec ·
+Debugging = arreglar la spec/plan que generó código incorrecto · Refactor = reestructurar para
+claridad.* El objetivo no es reemplazar al humano: es **amplificarlo automatizando la traducción
+mecánica** spec→código, dejando criterio/creatividad para la persona.
+
+## 0.1 Cuándo aplica / cuándo NO
+- **SÍ**: feature/proyecto NUEVO no trivial · requerimiento ambiguo que hay que aterrizar ·
+  cuando "saltar a código" produciría re-trabajo · cuando varias personas/agentes deben alinearse.
+- **NO**: fix de una línea · refactor puro · bug ya reproducible (→ `systematic-debugging`) ·
+  exploración throwaway. **No sobre-procesar lo trivial** (mismo principio de `caza-bugs`).
+- **Combina con**: `arquitecto-software` (los 6 pilares en /plan), `caza-bugs` (recorrer el camino
+  vivo en /implement), `comite-expertos`/`proceso-decision-fuerte` (decisiones fuertes del /plan),
+  `test-driven-development` (el test-first de la constitución).
+
+## 1. Las 3 separaciones innegociables
+| Artefacto | Responde | Contiene | NO contiene |
+|---|---|---|---|
+| **Spec** (QUÉ/POR-QUÉ) | qué necesita el usuario y por qué | user stories priorizadas (P1/P2/P3), criterios de aceptación Given-When-Then, requisitos `FR-###`, criterios de éxito MEDIBLES y agnósticos de tecnología | stack, APIs, esquema de datos, estructura de código |
+| **Plan** (CÓMO) | con qué tecnología y arquitectura | contexto técnico, elección de stack CON rationale, modelo de datos, contratos de API, escenarios de test, gates de constitución | el desglose de tareas (eso va en tasks) |
+| **Tasks** | en qué orden y qué se paraleliza | `[ID] [P?] [Story] Descripción`, dependencias, test-antes-de-implementación | decisiones de arquitectura nuevas (ya están en plan) |
+
+Si te descubres metiendo "React/Postgres/endpoint" en la **spec** → STOP, eso es plan. La spec
+sobrevive a los cambios de tecnología.
+
+## 2. La regla [NEEDS CLARIFICATION] (honestidad epistémica — el corazón del método)
+**No adivines.** Cuando la spec no define algo, márcalo: `[NEEDS CLARIFICATION: método de auth no
+especificado — email/contraseña, SSO, OAuth?]`. Un LLM que rellena huecos con suposiciones
+plausibles-pero-equivocadas es la fuente nº1 de re-trabajo. Los marcadores:
+- fuerzan checkpoints de revisión con el dueño,
+- mantienen la spec testeable,
+- **son un GATE**: "no quedan marcadores [NEEDS CLARIFICATION]" debe cumplirse ANTES de planear.
+Esto es el mismo ADN que el §3.3 del cerebro ("verifica, no asumas") aplicado a requisitos.
+
+## 3. La Constitución (el ADN arquitectónico)
+Antes de specs, fija los principios NO-negociables del proyecto en `constitution.md`
+(plantilla → `references/constitution-template.md`). Defaults fuertes de spec-kit:
+- **Test-First (NO-NEGOCIABLE)**: no se escribe código de implementación antes de tests escritos,
+  aprobados, y confirmados en ROJO (fallando). Invierte el reflejo de la IA de "código primero".
+- **Simplicidad / Anti-abstracción**: empezar mínimo (≤ pocos proyectos), usar el framework
+  directo en vez de envolverlo; toda capa de complejidad se JUSTIFICA en "Complexity Tracking".
+- **Integración real**: preferir BD/servicios reales sobre mocks; contract tests antes de implementar.
+- **Artículos del proyecto**: slots para los no-negociables propios (seguridad, versionado, perf…).
+  En Altorra: cero-fugas-de-leads, Ocultar≠Borrar, run-paralelo, Ley 1581/legal con abogado.
+La constitución es estable; enmendarla exige rationale + aprobación + evaluación de compatibilidad.
+
+## 4. El flujo de 7 fases (el playbook)
+Ejecuta en orden; cada fase produce un artefacto y pasa su gate antes de seguir. Detalle
+comando-por-comando + checklists → `references/workflow.md`.
+
+1. **constitution** → `constitution.md`. Principios de gobernanza. (Una vez por proyecto; reusar.)
+2. **specify** → `specs/<NNN-slug>/spec.md` (plantilla `references/spec-template.md`). La idea →
+   spec estructurada: user stories P1/P2/P3 *independientemente testeables*, requisitos `FR-###`,
+   criterios de éxito medibles. Marca ambigüedades con `[NEEDS CLARIFICATION]`.
+3. **clarify** → resuelve los `[NEEDS CLARIFICATION]` con preguntas estructuradas al dueño; anexa
+   sección "Clarifications". **Gate: cero marcadores abiertos** antes de planear.
+4. **plan** → `specs/<...>/plan.md` (+ `data-model.md`, `contracts/`, `research.md`, `quickstart.md`;
+   plantilla `references/plan-template.md`). Stack + arquitectura + **Constitution Check** (gate
+   antes de Fase 0; re-check tras el diseño). Aquí aplica `arquitecto-software` (6 pilares).
+   → **Audita el plan** con el subagente **`plan-auditor`** (revisión adversarial vs constitución+spec,
+   caza sobre-ingeniería y requisitos sin cubrir) ANTES de generar tareas.
+5. **tasks** → `specs/<...>/tasks.md` (plantilla `references/tasks-template.md`). Desglose ordenado
+   por fases (Setup → Foundational[bloquea todo] → User Stories[por prioridad, paralelizables] →
+   Polish), notación `[ID] [P?] [Story]`, test-antes-de-implementación.
+6. **analyze** (opcional, recomendado) → validación CRUZADA spec↔plan↔tasks: huecos de cobertura,
+   inconsistencias, requisitos sin tarea, tareas sin requisito. No edita; reporta. → subagente
+   **`spec-analyze`** (read-only) hace exactamente esto y devuelve veredicto READY / NOT-READY.
+7. **implement** → ejecuta las tareas en orden, TDD donde aplique. Al tocar estado observable,
+   recorre el **camino vivo** (`caza-bugs`). Verifica contra los criterios de éxito de la spec.
+
+Extras de spec-kit: `converge` (medir código vs spec → tareas faltantes), `checklist` (checklist de
+calidad por dominio), `taskstoissues` (tasks → GitHub issues).
+
+## 5. Plantilla-como-prompt (por qué las plantillas son el truco)
+Las plantillas no son formularios: son *prompts que restringen al LLM hacia calidad* —
+(1) fuerzan el nivel de abstracción correcto (spec sin tecnología), (2) obligan a marcar
+incertidumbre, (3) traen checklists que actúan como "tests unitarios de la spec", (4) ordenan
+test-antes-de-código, (5) prohíben features especulativas ("might need" → cada feature trazable a
+una user story concreta). Usa SIEMPRE la plantilla de `references/`; no improvises la estructura.
+
+## 6. Adaptación a Claude Code (sin el CLI `specify`)
+- Escribe los artefactos en `specs/<NNN-slug>/` del repo activo (o donde el proyecto convenga).
+- Numera features secuencialmente (`001`, `002`, …); slug semántico del nombre.
+- Si el proyecto YA tiene su propia disciplina (p.ej. el cerebro Altorra: ADR/IAP §37/spec en
+  `docs/superpowers/specs/`), **mapea** las fases a esa disciplina en vez de duplicar — la spec de
+  spec-kit ≈ el IAP+spec; el plan ≈ el ADR de diseño; analyze ≈ el review adversarial.
+- Para un proyecto sin disciplina propia, esto ES la disciplina: úsalo tal cual.
+
+## 7. El gate de cierre (no es teatro)
+Una corrida SDD está completa cuando: spec sin `[NEEDS CLARIFICATION]` · plan pasó Constitution
+Check · tasks cubren todos los `FR-###` (analyze limpio) · implement verificado contra los
+criterios de éxito MEDIBLES de la spec (no "parece andar"). Si falta uno, vuelve a su fase.
+
+## 8. Subagentes companion (las "herramientas" del método)
+Dos subagentes read-only (en `~/.claude/agents/`; fuente versionada en `agents/` de esta skill):
+- **`plan-auditor`** — revisión adversarial del `plan.md` vs constitución+spec ANTES de tareas
+  (caza sobre-ingeniería, complejidad sin justificar, requisitos sin cubrir). Sesgo: simplicidad.
+- **`spec-analyze`** — chequeo CRUZADO spec↔plan↔tasks ANTES de implementar (FR sin tarea, tareas
+  huérfanas, `[NEEDS CLARIFICATION]` abiertos, violaciones de constitución). Veredicto READY/NOT.
+Ambos REPORTAN, no editan (fiel a "analyze no edita"). Invócalos por nombre vía Task.
+
+> Crédito: método y plantillas derivados de **github/spec-kit** (MIT). Esta skill es una adaptación
+> portable; la fuente canónica del CLI/commands evoluciona en el repo original.

--- a/skills/spec-kit/agents/plan-auditor.md
+++ b/skills/spec-kit/agents/plan-auditor.md
@@ -1,0 +1,35 @@
+---
+name: plan-auditor
+description: Adversarial reviewer of a Spec-Driven Development implementation plan (plan.md) BEFORE tasks/implementation. Audits the plan against the constitution and the spec — hunting over-engineering, missed requirements, unjustified complexity, and premature/wrong tech choices. Read-only; reports, does not edit. Invoke when the user says "audit my plan", "review the implementation plan", "is this plan over-engineered", "does the plan honor the constitution", or between `/plan` and `/tasks`. Pair with the `spec-kit` skill.
+tools: Read, Grep, Glob
+---
+
+You are **plan-auditor**, an adversarial reviewer of implementation plans in Spec-Driven Development. You audit a `plan.md` (with its `spec.md` and `constitution.md`) BEFORE it becomes tasks and code. You are read-only: you REPORT, you never edit. Your bias is toward SIMPLICITY — the cheapest plan that satisfies the spec wins.
+
+## Inputs
+Locate (via Glob under `specs/<feature>/`): `plan.md` (required), `spec.md` (required for traceability), `constitution.md` (the governing articles), and optionally `data-model.md`, `contracts/`, `research.md`.
+
+## What you audit (cite evidence: file:section)
+1. **Constitution compliance** — the core job:
+   - **Test-First**: does the plan sequence tests before implementation? If not → CRITICAL.
+   - **Simplicity**: is this the minimal structure? Count projects/layers/services. Flag every layer not demanded by a requirement.
+   - **Anti-abstraction**: does the plan wrap frameworks/libraries in custom abstractions without a demonstrated need? Flag each wrapper.
+   - **Integration-real**: are contract tests + real services used where risk warrants, instead of mocks?
+2. **Requirement traceability**: every `FR-###` in the spec maps to a concrete design decision/contract in the plan. List any requirement the plan does NOT address. Also flag plan elements that serve NO requirement (gold-plating).
+3. **Premature / wrong tech**: technology choices with weak or missing rationale; choices that contradict the spec's constraints; a "Research" phase that decided without alternatives. Every stack choice should name what it beat and why.
+4. **Complexity Tracking honesty**: if the plan exceeds the simplicity baseline, is each extra justified in the Complexity Tracking table with a discarded simpler alternative? An unjustified complexity is a finding.
+5. **Risk & reversibility**: which decisions are expensive to reverse (data model, public API, auth, money flows)? Are they the ones that got the most scrutiny? Flag big-bang/irreversible moves that could be staged.
+6. **Architect's 6 pillars** (if the project uses `arquitecto-software`): business-vision · scalability · security · cost · maintainability · communication — name any pillar the plan ignored.
+
+## Discipline
+- **Verify against the files; quote what you flag.** Default to challenging complexity: make the plan JUSTIFY every layer, wrapper, service, and dependency. "Could a junior delete this and still pass the spec?" → if yes, it's a finding.
+- Be specific and constructive: each finding names the simpler alternative in one line. But you do not edit — the human/main agent decides.
+- Distinguish FACT (violates a written article) from JUDGMENT (you'd do it differently) — label which.
+
+## Output
+1. **Verdict**: APPROVED | APPROVED-WITH-CHANGES | REWORK (with the count of CRITICAL findings).
+2. **Findings table**: `| ID | Severity | Pillar/Article | Finding | Evidence | Simpler alternative |`.
+3. **Constitution scorecard**: one line per article — ✅ / ⚠️ / ❌.
+4. Bottom line: the single change that most improves the plan.
+
+You are the check that stops an over-engineered or spec-divergent plan from becoming a thousand lines of wrong code.

--- a/skills/spec-kit/agents/spec-analyze.md
+++ b/skills/spec-kit/agents/spec-analyze.md
@@ -1,0 +1,32 @@
+---
+name: spec-analyze
+description: Cross-artifact consistency checker for Spec-Driven Development (the spec-kit `/analyze` step as a subagent). Use after a spec.md + plan.md + tasks.md exist, BEFORE implementing, to catch coverage gaps and inconsistencies. It is read-only and adversarial: it reports problems, it does NOT edit. Invoke when the user says "analyze my spec/plan/tasks", "check coverage", "are my tasks consistent with the spec", "cross-validate the SDD artifacts", or right before `/implement`. Pair with the `spec-kit` skill.
+tools: Read, Grep, Glob
+---
+
+You are **spec-analyze**, an adversarial consistency auditor for Spec-Driven Development (the GitHub spec-kit `/speckit.analyze` step). You are read-only: you REPORT, you never edit. Your job is to catch, before any code is written, the gaps that make an implementation diverge from intent.
+
+## Inputs
+You are given (or you locate via Glob under `specs/<feature>/`): `spec.md`, `plan.md`, `tasks.md`, and optionally `constitution.md`, `data-model.md`, `contracts/`. If any required file is missing, say so and analyze what exists.
+
+## What you check (be exhaustive, cite file:section/line)
+1. **Coverage — spec → tasks**: every functional requirement `FR-###` in the spec maps to ≥1 task in tasks.md. List any `FR-###` with NO task (a feature that will silently not get built).
+2. **Orphans — tasks → spec**: every task traces to an `FR-###` or a constitution article. List tasks with no traceable source (scope creep / speculative work).
+3. **Residual ambiguity**: any `[NEEDS CLARIFICATION]` marker still open in spec or plan (a hard gate — must be zero before implementing).
+4. **Spec↔plan drift**: the plan honors the spec's WHAT/WHY; flag where the plan silently changed a requirement, dropped a user story, or where the spec leaked technology (stack/API/schema in the spec).
+5. **Constitution violations**: check plan + tasks against each constitution article — especially Test-First (tests ordered before implementation), Simplicity / Anti-abstraction (unjustified complexity), Integration-real. Flag violations or missing "Complexity Tracking" justification.
+6. **Success-criteria testability**: every measurable Success Criterion (SC-###) in the spec has a corresponding test/validation task. Flag unmeasurable criteria ("fast", "easy") and untested ones.
+7. **Task ordering**: within each user story, tests precede implementation; Foundational precedes user stories; `[P]` tasks genuinely touch different files (no hidden conflict).
+
+## Discipline
+- **Verify against the actual files, don't assume.** Quote the exact `FR-###`, task ID, or line you're flagging. A finding without evidence is noise.
+- **Severity**: CRITICAL (will ship wrong/incomplete), MAJOR (likely re-work), MINOR (polish). Default to skepticism — when uncertain whether something is covered, flag it for the human, don't wave it through.
+- Do NOT propose fixes as edits; you may suggest the corrective action in one line, but the main agent/human decides.
+
+## Output (structured, machine-scannable)
+1. **Verdict**: READY TO IMPLEMENT | NOT READY (with the blocking count).
+2. **Findings table**: `| ID | Severity | Category | Finding | Evidence (file:where) | Suggested action |`.
+3. **Coverage summary**: `N FR total · M with tasks · K uncovered`; `T tasks total · O orphans`; `C [NEEDS CLARIFICATION] open`.
+4. One-line bottom line: the single most important thing to fix first.
+
+Keep it tight and falsifiable. You are the gate that stops a plausible-but-wrong build.

--- a/skills/spec-kit/references/constitution-template.md
+++ b/skills/spec-kit/references/constitution-template.md
@@ -1,0 +1,49 @@
+# Constitución del proyecto: [NOMBRE]
+
+> El "ADN arquitectónico": principios NO-negociables que TODA spec, plan y código deben cumplir.
+> Derivada de github/spec-kit (MIT). Estable; enmendarla exige rationale + aprobación + evaluación
+> de compatibilidad. `/analyze` valida los artefactos contra estos artículos.
+
+**Versión**: 1.0.0 · **Ratificada**: <YYYY-MM-DD> · **Última enmienda**: <YYYY-MM-DD>
+
+## Artículos núcleo (defaults fuertes de spec-kit — ajusta a tu contexto)
+
+### Artículo I — Test-First (NO-NEGOCIABLE)
+No se escribe código de implementación antes de: (1) tests escritos, (2) aprobados por el dueño,
+(3) confirmados FALLANDO (rojo). Invierte el reflejo de la IA de "código primero".
+
+### Artículo II — Simplicidad
+Empezar con la estructura MÍNIMA (≤ N proyectos/módulos). Toda complejidad adicional se justifica
+en "Complexity Tracking" del plan o no entra. YAGNI por defecto.
+
+### Artículo III — Anti-abstracción
+Usar las capacidades del framework DIRECTAMENTE; no envolver en abstracciones propias sin una
+razón demostrada. Cada wrapper se gana su lugar.
+
+### Artículo IV — Integración real
+Preferir BD/servicios reales sobre mocks donde el riesgo lo amerite. Contract tests obligatorios
+antes de implementar integraciones.
+
+### Artículo V — Observabilidad
+<Logs/telemetría/trazas mínimas que toda feature debe exponer.>
+
+## Artículos del proyecto  *(los no-negociables PROPIOS — esto es lo que te diferencia)*
+
+### Artículo VI — <Seguridad / privacidad>
+<ej. Altorra: cero-fugas-de-leads · datos personales con consentimiento (Ley 1581) · texto legal
+público solo con revisión de abogado.>
+
+### Artículo VII — <Despliegue / cambio>
+<ej. Altorra: Ocultar≠Borrar · run-paralelo hasta paridad · rollback por gate · deploy de
+dinero/prod bajo doble-llave + staging.>
+
+### Artículo VIII — <Versionado / compatibilidad>
+<reglas de breaking changes, migraciones, deprecación.>
+
+## Gobernanza
+- **Precedencia**: ante conflicto, la constitución gana sobre conveniencia.
+- **Enmienda**: propuesta con rationale → revisión del dueño/maintainers → evaluación de
+  compatibilidad hacia atrás → bump de versión (semver: MAJOR=quita/redefine un artículo,
+  MINOR=agrega, PATCH=aclara).
+- **Cumplimiento**: `/analyze` y los gates de `/plan` verifican cada artículo; un ⚠️ se resuelve
+  (simplificar) o se justifica explícitamente.

--- a/skills/spec-kit/references/plan-template.md
+++ b/skills/spec-kit/references/plan-template.md
@@ -1,0 +1,55 @@
+# Implementation Plan: [NOMBRE DE LA FEATURE]
+
+> Plantilla de **plan** (CÓMO). Derivada de github/spec-kit (MIT). Traduce la spec aprobada a
+> arquitectura técnica CON rationale. Aplica `arquitecto-software` (6 pilares). Output esperado:
+> `plan.md` → `research.md` → `data-model.md` → `quickstart.md` → `contracts/` → (luego) `tasks.md`.
+
+**Feature ID**: `<NNN-slug>` · **Spec**: `./spec.md` · **Fecha**: <YYYY-MM-DD>
+
+## 1. Technical Context
+- **Lenguaje/runtime**: <…>  · **Dependencias clave**: <…>
+- **Almacenamiento**: <BD/colas/cache>  · **Testing**: <framework + niveles>
+- **Plataforma/target**: <web/mobile/CLI/server>  · **Restricciones de performance**: <umbrales>
+- **Restricciones del proyecto**: <legal, seguridad, presupuesto, equipo>
+
+## 2. Constitution Check  *(GATE — debe pasar ANTES de la Fase 0; re-check tras el diseño)*
+> Verifica el plan contra `constitution.md`. Cada artículo: ✅ cumple / ⚠️ requiere justificación.
+- [ ] **Test-First**: el plan ordena tests ANTES de implementación.
+- [ ] **Simplicidad**: estructura mínima (≤ N proyectos); sin capas no justificadas.
+- [ ] **Anti-abstracción**: usa el framework directo; no wrappers innecesarios.
+- [ ] **Integración real**: contract tests + servicios reales sobre mocks donde importa.
+- [ ] **Artículos del proyecto**: <listar y verificar los no-negociables propios>.
+> Cualquier ⚠️ → documentar en §6 Complexity Tracking con justificación, o simplificar.
+
+## 3. Project Structure
+> Dónde viven los archivos. Elegir UN patrón (single project / web app / mobile+API) y mostrarlo.
+```
+specs/<NNN-slug>/
+  spec.md · plan.md · research.md · data-model.md · quickstart.md · contracts/ · tasks.md
+src/  ...   tests/  ...
+```
+
+## 4. Phase 0 — Research  *(→ research.md)*
+- Preguntas abiertas del stack/dominio; benchmarks, compatibilidades, restricciones org.
+- Para cada decisión: opciones consideradas → elegida → **rationale** → descartadas y por qué.
+- Decisiones FUERTES (caras de revertir) → escalar (`proceso-decision-fuerte` / `comite-expertos`).
+
+## 5. Phase 1 — Design  *(→ data-model.md, contracts/, quickstart.md)*
+- **Data model**: entidades, campos, relaciones, invariantes (deriva de "Key Entities" de la spec).
+- **Contracts**: contratos de API/interfaces (request/response, errores) en `contracts/`.
+- **Test scenarios**: mapear cada criterio de aceptación G-W-T a un test de contrato/integración.
+- **Quickstart**: cómo validar la feature end-to-end (el guion de aceptación).
+- **Trazabilidad**: cada `FR-###` de la spec → decisión/contrato que lo cumple.
+
+## 6. Complexity Tracking
+> SOLO si algún Constitution Check salió ⚠️. Tabla: cada complejidad extra se gana su lugar.
+| Complejidad introducida | Por qué es necesaria | Alternativa más simple descartada y por qué |
+|---|---|---|
+| <…> | <…> | <…> |
+
+## 7. Progress / Gates
+- [ ] Constitution Check inicial ✅
+- [ ] Phase 0 research cerrado (sin decisiones abiertas)
+- [ ] Phase 1 design completo (data-model + contracts + quickstart)
+- [ ] Constitution Check re-check tras diseño ✅
+- [ ] Listo para `/tasks`

--- a/skills/spec-kit/references/spec-template.md
+++ b/skills/spec-kit/references/spec-template.md
@@ -1,0 +1,69 @@
+# Feature Specification: [NOMBRE DE LA FEATURE]
+
+> Plantilla de **spec** (QUÉ/POR-QUÉ). Derivada de github/spec-kit (MIT). Reglas:
+> - Describe necesidades de USUARIO y NEGOCIO, no tecnología. CERO stack/APIs/esquema/código.
+> - Marca todo lo no especificado con `[NEEDS CLARIFICATION: pregunta concreta]`. NO adivines.
+> - Cada user story debe ser **independientemente testeable** (entrega valor sola).
+> - Criterios de éxito **medibles y agnósticos de tecnología**.
+> - Reemplaza los ejemplos genéricos por contenido real antes de planear (ACTION REQUIRED).
+
+**Feature ID**: `<NNN-slug>` · **Branch**: `<NNN-slug>` · **Estado**: Draft | Clarified | Planned
+**Fecha**: <YYYY-MM-DD> · **Dueño de la decisión**: <quién aprueba>
+
+## 1. Resumen (1 párrafo)
+Qué es y para quién, en lenguaje de negocio. El "por qué" en una frase.
+
+## 2. User Scenarios & Testing  *(obligatorio)*
+> Historias priorizadas. P1 = MVP imprescindible · P2 = importante · P3 = deseable.
+> Cada una INDEPENDIENTE: se puede desarrollar, testear y desplegar sola.
+
+### US1 — [título] (Prioridad: P1)
+**Como** <rol> **quiero** <capacidad> **para** <beneficio>.
+**Por qué esta prioridad**: <justificación de valor>.
+**Test independiente**: <cómo se prueba sola, sin las otras historias>.
+**Criterios de aceptación** (Given-When-Then):
+- **Given** <contexto> **When** <acción> **Then** <resultado observable>.
+- **Given** … **When** … **Then** …
+
+### US2 — [título] (Prioridad: P2)
+… (mismo formato)
+
+### US3 — [título] (Prioridad: P3)
+…
+
+## 3. Edge Cases  *(obligatorio)*
+- Condiciones de borde, entradas inválidas, estado-cero (vacío→1, N→vacío), concurrencia.
+- Qué pasa cuando <falla X>? Cómo se comunica al usuario?
+
+## 4. Requirements  *(obligatorio)*
+> Funcionales numerados `FR-###`. Cada uno trazable a ≥1 user story. Sin tecnología.
+- **FR-001**: El sistema DEBE <comportamiento observable>.
+- **FR-002**: El sistema DEBE <…>.
+- **FR-003**: El sistema DEBE <…> `[NEEDS CLARIFICATION: <qué falta definir>]`.
+
+### Requisitos no funcionales (si aplica)
+- **NFR-001**: <performance / seguridad / accesibilidad / legal> con umbral medible.
+
+## 5. Key Entities  *(si hay datos)*
+> Conceptos del dominio (NO esquema de BD). Nombre + qué representa + relaciones clave.
+- **<Entidad>**: <qué es>; se relaciona con <…>.
+
+## 6. Success Criteria  *(obligatorio — medibles, agnósticos de tecnología)*
+- **SC-001**: <métrica observable> alcanza <umbral> (ej: "el usuario completa la compra en ≤ 3 pasos").
+- **SC-002**: <…>.
+> Mal: "la API responde rápido". Bien: "el resultado aparece en < 2 s para el 95% de los casos".
+
+## 7. Assumptions
+- Decisiones por defecto sobre alcance, usuarios y dependencias (lo que se asume si nadie objeta).
+
+## 8. Out of Scope
+- Lo que esta feature explícitamente NO hace (anti-scope-creep).
+
+---
+## ✅ Checklist de calidad de la spec (gate antes de /plan)
+- [ ] CERO marcadores `[NEEDS CLARIFICATION]` abiertos.
+- [ ] Cada user story es independientemente testeable y tiene prioridad.
+- [ ] Cada `FR-###` traza a una user story; ninguno trae tecnología.
+- [ ] Criterios de éxito medibles y agnósticos de tecnología.
+- [ ] Sin features especulativas ("might need"); todo traza a una historia real.
+- [ ] Edge cases y estado-cero cubiertos.

--- a/skills/spec-kit/references/tasks-template.md
+++ b/skills/spec-kit/references/tasks-template.md
@@ -1,0 +1,55 @@
+# Tasks: [NOMBRE DE LA FEATURE]
+
+> Plantilla de **tasks**. Derivada de github/spec-kit (MIT). Deriva del plan: cada contrato,
+> entidad y escenario → tareas concretas. NO introduce decisiones de arquitectura nuevas.
+> **Notación**: `[ID] [P?] [Story] Descripción`
+> - `[ID]` secuencial: `T001`, `T002`, … · `[P]` = paralelizable (sin dependencia con otras [P]
+>   del mismo grupo; tocan archivos distintos) · `[Story]` = etiqueta de user story (`US1`/`US2`/…).
+> - Cada tarea nombra el/los **archivos** que toca.
+
+**Feature ID**: `<NNN-slug>` · **Plan**: `./plan.md`
+
+## Orden de dependencias (reglas)
+1. **Setup** primero (todo lo demás depende).
+2. **Foundational** bloquea TODAS las user stories (infra crítica compartida).
+3. **User Stories** pueden ir en paralelo entre sí tras Foundational; dentro de cada una:
+   **tests antes de implementación**, **modelos antes de servicios**, servicios antes de UI.
+4. **Polish** al final (cross-cutting).
+
+---
+## Phase 1 — Setup
+- [ ] **T001** Inicializar estructura/deps según plan §3. (`<archivos>`)
+- [ ] **T002** [P] Configurar linter/formatter/test runner. (`<archivos>`)
+
+## Phase 2 — Foundational  *(MUST complete antes de CUALQUIER user story)*
+- [ ] **T003** <infra compartida: auth base, conexión BD, esquema raíz>. (`<archivos>`)
+- [ ] **T004** [P] <otra pieza foundational independiente>. (`<archivos>`)
+
+## Phase 3 — US1 (P1, MVP)
+- [ ] **T005** [P] [US1] **Test** de contrato/aceptación para <FR-00x> (debe FALLAR primero). (`tests/...`)
+- [ ] **T006** [US1] Modelo/entidad <…>. (`src/...`)
+- [ ] **T007** [US1] Servicio/lógica <…> (hace pasar T005). (`src/...`)
+- [ ] **T008** [US1] UI/endpoint <…>. (`src/...`)
+
+## Phase 4 — US2 (P2)
+- [ ] **T009** [P] [US2] Test … (FALLA primero). (`tests/...`)
+- [ ] **T010** [US2] Implementación … (`src/...`)
+
+## Phase 5 — US3 (P3)
+- [ ] **T0xx** [US3] …
+
+## Phase 6 — Polish  *(cross-cutting)*
+- [ ] **T0xx** [P] Manejo de errores/edge cases de la spec §3. (`<archivos>`)
+- [ ] **T0xx** [P] Accesibilidad / performance / docs.
+- [ ] **T0xx** Verificar contra los **Success Criteria** medibles de la spec §6.
+
+---
+## Estrategia de paralelización
+- Tras Foundational: US1 ‖ US2 ‖ US3 (equipos/agentes distintos).
+- Dentro de una story: tareas `[P]` que tocan archivos distintos corren juntas.
+- Los tests `[P]` de una story se escriben juntos ANTES de su implementación (test-first).
+
+## Trazabilidad (gate de /analyze)
+- [ ] Cada `FR-###` de la spec tiene ≥1 tarea.
+- [ ] Cada tarea traza a un `FR-###` o a un artículo de la constitución (sin tareas huérfanas).
+- [ ] Cada user story tiene su test antes de su implementación.

--- a/skills/spec-kit/references/workflow.md
+++ b/skills/spec-kit/references/workflow.md
@@ -1,0 +1,67 @@
+# Workflow comando-por-comando (playbook SDD)
+
+> Cómo ejecutar cada fase de spec-kit en Claude Code (sin el CLI `specify`). Derivado de
+> github/spec-kit (MIT). El CLI original expone estos como slash-commands `/speckit.*`; aquí
+> son pasos que YO ejecuto leyendo la plantilla correspondiente de `../references/`.
+
+## Mapa rápido
+| Fase | Comando spec-kit | Entrada | Salida | Plantilla |
+|---|---|---|---|---|
+| 1 | `/speckit.constitution` | principios de calidad/test/UX/perf | `constitution.md` | constitution-template |
+| 2 | `/speckit.specify` | descripción de la feature | `specs/<id>/spec.md` | spec-template |
+| 3 | `/speckit.clarify` | huecos de la spec | "Clarifications" en spec.md | — |
+| 4 | `/speckit.plan` | spec aprobada + stack | `plan.md`+`data-model.md`+`contracts/` | plan-template |
+| 5 | `/speckit.tasks` | plan validado | `tasks.md` | tasks-template |
+| 6 | `/speckit.analyze` | spec+plan+tasks | reporte de inconsistencias | — |
+| 7 | `/speckit.implement` | todo lo anterior | código + tests | — |
+| + | `converge` | código + spec | tareas faltantes | — |
+| + | `checklist` | criterios de calidad | checklist por dominio | checklist |
+| + | `taskstoissues` | tasks.md | GitHub issues | — |
+
+## 1. constitution
+1. Pregunta/define los no-negociables del proyecto (test, simplicidad, seguridad, legal, deploy).
+2. Rellena `constitution-template.md` → `constitution.md` (en `memory/` o donde el proyecto guarde gobernanza).
+3. Una vez por proyecto; reusar/enmendar, no recrear.
+
+## 2. specify
+1. Toma la descripción de la feature. Numérala (`001`, `002`, …) + slug semántico → `specs/<NNN-slug>/`.
+2. Rellena `spec-template.md`. **Disciplina**: solo QUÉ/POR-QUÉ; cero tecnología.
+3. Donde no sepas, escribe `[NEEDS CLARIFICATION: <pregunta>]`. NO adivines.
+4. Corre el checklist de la spec. Si no pasa, no avances.
+
+## 3. clarify  *(gate antes de plan)*
+1. Lista todos los `[NEEDS CLARIFICATION]`.
+2. Conviértelos en preguntas concretas al dueño (agrupadas, priorizadas).
+3. Anexa las respuestas en una sección "Clarifications" + actualiza los `FR-###` afectados.
+4. **Gate**: cero marcadores abiertos. Solo entonces → plan.
+
+## 4. plan
+1. Lee la spec aprobada. Rellena `plan-template.md`.
+2. **Constitution Check ANTES de research** (gate). Aplica `arquitecto-software` (6 pilares).
+3. Phase 0 research (decisiones con rationale; las fuertes → escalar). Phase 1 design
+   (data-model, contracts, quickstart, trazabilidad FR→decisión).
+4. **Re-check Constitution** tras el diseño. ⚠️ → Complexity Tracking o simplificar.
+
+## 5. tasks
+1. Lee plan.md (+ data-model/contracts). Rellena `tasks-template.md`.
+2. Deriva tareas de contratos/entidades/escenarios. Ordena por fases (Setup→Foundational→Stories→Polish).
+3. Marca `[P]` lo paralelizable; test-antes-de-implementación dentro de cada story.
+
+## 6. analyze  *(recomendado)*
+Cruza spec ↔ plan ↔ tasks. Reporta (NO edita):
+- `FR-###` sin tarea (cobertura faltante) · tareas sin `FR`/artículo (huérfanas).
+- Inconsistencias spec↔plan · ambigüedades residuales · violaciones de constitución.
+En Altorra esto ≈ el review adversarial; escala con `adversarial-review`/`caza-bugs` si el riesgo lo amerita.
+
+## 7. implement
+1. Ejecuta `tasks.md` en orden. TDD donde la constitución lo exige (test rojo → verde).
+2. Al tocar estado observable → `caza-bugs` (recorrer el camino vivo, estado-cero).
+3. **Verifica contra los Success Criteria MEDIBLES de la spec** (no "parece andar").
+4. Cierre: spec sin marcadores · Constitution Check ✅ · analyze limpio · criterios cumplidos.
+
+## Anti-patrones (qué NO hacer)
+- Saltar de la idea directo al código (el problema que SDD resuelve).
+- Meter tecnología en la spec / requisitos de negocio en el plan.
+- Rellenar huecos con suposiciones en vez de `[NEEDS CLARIFICATION]`.
+- Tareas sin archivos nombrados · implementación antes del test (viola Test-First).
+- Sobre-procesar lo trivial: para un fix de una línea, esto es overkill (ver SKILL §0.1).


### PR DESCRIPTION
… subagentes ⟦OPUS-4.8⟧

Consolidación cross-brain (pedido del dueño): la skill `spec-kit` (método SDD de GitHub spec-kit, MIT) ya estaba global (~/.claude/skills) = usable aquí; esto agrega la copia VERSIONADA en este repo (durabilidad git, patrón de las portables).

- skills/spec-kit/ : SKILL.md (playbook 7 fases) + references/ (spec/plan/tasks/ constitution-template + workflow) + agents/ (spec-analyze, plan-auditor — fuente versionada de los subagentes que viven en ~/.claude/agents/).
- Catalogada en docs/skills-inventory.md. Crédito a github/spec-kit (MIT).

Modelo: Opus 4.8