### PR TITLE
feat(skills): propaga el Paquete de Visibilidad — 7 skills + agente s…

### DIFF
--- a/docs/skills-inventory.md
+++ b/docs/skills-inventory.md
@@ -32,6 +32,27 @@ de mis capacidades. Implicaciones:
 
 ---
 
+## 🌐 Paquete de Visibilidad (propagado por el HUB Altorra Cars · ADR §244 cars · 2026-06-25)
+> 7 skills PORTABLES (vertical JewelryStore/AutoDealer/RealEstateAgent vía `tenant_config.json`) + agente
+> `seo-auditor` (read-only), propagadas **byte-idénticas** desde el HUB (Altorra Cars). Arquitectura HUB
+> **IoC + core-funciones-puras + D′ vendored**. La IMPLEMENTACIÓN en este sitio (tenant_config + templates +
+> `visibility-core` + wiring) la hace la sesión de ESTE proyecto, con datos REALES del dueño (cero-demo).
+> Onboarding/checklist → `skills/ssg-static-prerender/references/onboarding-nuevo-proyecto-al-hub.md`.
+> Reglas: schema-en-HTML-del-build · cero-demo · status:published · slug inmutable · NAP maestro · Consent Mode v2.
+
+| Skill (name) | Para qué | Disp. |
+|---|---|---|
+| `ssg-static-prerender` | Hornear HTML real por ítem en el build (la BASE; lleva la arquitectura HUB + `tenant_config` + contrato IoC del core en `references/`). | ✅ |
+| `semantic-schema-aeo` | Structured data por tipo de página + AEO (ser citado por IA; 20% código/80% off-page). FUSIÓN schema+answer-engine. | ✅ |
+| `ga4-lead-tracking` | GA4 por LEAD (no purchase) + Consent Mode v2 (Ley 1581) + links WhatsApp trazables (dark-social). | ✅ |
+| `maps-gbp-local` | Local pack #1 / GBP: 3 ejes + NAP maestro + LocalBusiness schema + reseñas reales + inventario en GBP. | ✅ |
+| `search-console-setup-y-diagnostico` | Alta GSC + árbol de diagnóstico "no salgo en Google" + bucle mensual + API histórico. | ✅ |
+| `product-feeds` | Feeds en el build por vertical (Merchant/Vehicle+Local Inventory/FincaRaíz-Metrocuadrado) — empujar catálogo. | ✅ |
+| `image-pipeline` | WebP/AVIF + srcset + `width/height` (CWV) + `ImageObject` + alt real + EXIF geo opcional. NUNCA upscaling. | ✅ |
+| `seo-auditor` *(agente)* | Auditor read-only de visibilidad: verifica el HTML del build vs las reglas (schema-en-HTML, cero-demo, noindex, NAP, CWV). | ✅ agente |
+
+---
+
 ## 🧬 Proceso / Desarrollo (superpowers + dev)
 
 > Las 14 de `superpowers` están **doble-disponibles** (`superpowers:` y `anthropic-skills:`).

--- a/skills/ga4-lead-tracking/SKILL.md
+++ b/skills/ga4-lead-tracking/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: ga4-lead-tracking
+description: Medir lo que importa en un negocio offline/bajo-consulta (joya, carro, inmueble) con GA4 — el LEAD, no `purchase` — con Consent Mode v2 (Ley 1581 Colombia) y links de WhatsApp trazables (dark-social). Úsala al instrumentar analítica en cualquier sitio del paquete de visibilidad: GA4 por EVENTOS (no es factor de ranking, pero te dice QUÉ optimizar), key events `generate_lead`/`contact`/`whatsapp_click`/`view_item`, un solo helper `trackEvent(name,params)` (DRY, lee los mismos datos del ítem que el SSG), y un generador de links WhatsApp con UTM + hash de sesión + contexto del ítem prerelleno. Reglas duras: Consent Mode v2 default DENIED antes del config → update granted al aceptar el banner; NUNCA PII (tel/email/cédula) a GA4 ni en URL; verificar EN VIVO en DebugView (cero-demo); vincular GA4↔Search Console↔Ads. Portable por `tenant_config.json` (ga4MeasurementId). Triggers — "instalar GA4", "medir conversiones/leads", "consent mode", "trackear clicks de WhatsApp", "qué eventos mido", "analítica sin romper privacidad", "lead funnel". NO uses para e-commerce con checkout online (ahí sí `purchase`).
+---
+
+# 📊 GA4 Lead Tracking — medir el lead, no la compra (negocio offline Colombia)
+
+> Parte del paquete de visibilidad (HUB). GA4 NO mueve el ranking — guía QUÉ optimizar (qué fichas convierten,
+> de dónde vienen). Lee `tenant_config.json` (`ga4MeasurementId`; si vacío, no inyecta). El ID del dueño es ⛔ (lo pide la sesión-implementadora).
+
+## 0. La tesis
+Joya/carro/inmueble se venden **offline, "bajo consulta"** → NO hay `purchase` que medir. El evento de valor es
+el **LEAD**: el momento en que alguien pide info (WhatsApp, formulario, llamada). Medir eso = saber qué inventario/
+ciudad/canal trae clientes. En Colombia **todo cierra por WhatsApp** (dark-social) → hay que **trazar el click de WA**.
+
+## 1. Consent Mode v2 ANTES del config (Ley 1581 — no negociable)
+```html
+<!-- 1. consent default DENIED, ANTES de gtag config -->
+<script>
+  window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);}
+  gtag('consent', 'default', {
+    ad_storage:'denied', analytics_storage:'denied',
+    ad_user_data:'denied', ad_personalization:'denied'   // los 4 signals v2
+  });
+</script>
+<!-- 2. gtag.js async, ID desde build/env (VITE_GA_MEASUREMENT_ID / tenant_config) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXX"></script>
+<script>gtag('js', new Date()); gtag('config', 'G-XXXX', { anonymize_ip:true });</script>
+```
+Al **aceptar el banner** → `gtag('consent','update',{analytics_storage:'granted', ...})`. Sin aceptar, GA4 corre en
+modo cookieless básico (sin PII, sin cookies). El banner es CODIFICABLE; el texto legal exacto → revisión de abogado.
+
+## 2. Los key events (máx 2-3 de valor) — un solo helper DRY
+```js
+// js/analytics.js — lee los MISMOS datos del ítem que el SSG (PRERENDERED_*), cero duplicación.
+export function trackEvent(name, params = {}) {
+  if (typeof gtag !== 'function') return;
+  gtag('event', name, { ...params });   // NUNCA PII aquí
+}
+// Eventos:
+trackEvent('view_item', { items:[{ item_id:id, item_name:title, item_category:vertical }], currency:'COP' });
+trackEvent('whatsapp_click', { item_id:id, channel:'whatsapp', source:utmSource });   // ← key event
+trackEvent('generate_lead', { method:'form', item_id:id });                            // ← key event
+trackEvent('contact', { method:'phone' });
+```
+Marca `generate_lead`/`whatsapp_click` como **Key Events** en GA4. Máx 2-3 (no ruido).
+
+## 3. WhatsApp trazable (el cierre real — dark-social)
+Genera el link de WA en el build/cliente con UTM + hash de sesión + **contexto del ítem en el texto prerelleno**:
+```js
+function waLink(cfg, item, sessionHash) {
+  const text = `Hola, me interesa: ${item.title} (ref ${item.id}). Vi esto en ${cfg.baseUrl}`;
+  const utm = `utm_source=web&utm_medium=whatsapp&utm_campaign=ficha&item=${item.id}&s=${sessionHash}`;
+  // el contexto va en el TEXTO (lo lee el asesor), los UTM en el evento GA (no en PII)
+  return `https://wa.me/${cfg.nap.phone.replace(/\D/g,'')}?text=${encodeURIComponent(text)}`;
+}
+// onclick → trackEvent('whatsapp_click', {...}) ANTES de abrir wa.me
+```
+Así: GA4 cuenta el lead + el asesor recibe el contexto del ítem (sabe qué carro/joya sin preguntar). El hash de
+sesión liga la conversación al recorrido web SIN mandar PII a GA4.
+
+## 4. Reglas duras
+- **NUNCA PII** (teléfono/email/cédula/nombre) a GA4 ni en la URL. El contexto del ítem va en el TEXTO de WA, no en params GA.
+- **Verificar EN VIVO en DebugView** (no asumir que dispara — cero-demo): abre el sitio con `?debug_mode=1`, haz
+  cada acción, confirma el evento + params en GA4 DebugView. Un evento "instalado" pero que no dispara = inútil.
+- **Excluir tráfico interno** (IP del dueño/oficina) en GA4 Admin · vincular **GA4 ↔ Search Console ↔ Google Ads**.
+- Consent Mode v2 ANTES del config · `anonymize_ip`.
+
+## ✅ Checklist
+- [ ] Consent default DENIED (4 signals) cargado ANTES de `gtag('config')`.
+- [ ] `ga4MeasurementId` desde `tenant_config`/env (no hardcode).
+- [ ] `view_item` + `whatsapp_click` + `generate_lead` disparan y se ven en **DebugView en vivo**.
+- [ ] Links de WA con texto-contexto + evento `whatsapp_click` antes de abrir.
+- [ ] Cero PII en eventos/URL · key events marcados · tráfico interno excluido · GA4↔GSC↔Ads vinculados.

--- a/skills/image-pipeline/SKILL.md
+++ b/skills/image-pipeline/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: image-pipeline
+description: Optimizar imágenes en el BUILD para velocidad (Core Web Vitals) + SEO de imagen + señal local — porque en joyería/autos/inmuebles la imagen ES el producto y pesa el LCP. Úsala al procesar las fotos de cualquier sitio del paquete de visibilidad: generar WebP/AVIF (con fallback), dimensiones responsivas (`srcset`), `width`/`height` para matar CLS, `loading="lazy"`+`decoding="async"` below-fold y `fetchpriority="high"` SOLO en el LCP, `alt` descriptivo real, `ImageObject` JSON-LD, y EXIF geo (señal local menor/opcional). Corre en el build (Sharp/equivalente), como módulo del SSG. Reglas duras: NUNCA upscaling (verificar que la variante exista físicamente antes de referenciarla en `srcset`), `alt` real (cero-demo, no relleno), imágenes absolutas para feeds/OG. Triggers — "optimizar imágenes", "WebP/AVIF", "imágenes lentas/LCP", "srcset responsive", "alt text", "ImageObject schema", "EXIF geo", "fotos pesadas". Lee `tenant_config.json` (imageFormats, imageGeoExif). Fusionable con `ssg-static-prerender`. NUEVA en el paquete (Altorra ya usa `sharp` → se amplía).
+---
+
+# 🖼️ Image Pipeline — imágenes rápidas + indexables + locales
+
+> Parte del paquete de visibilidad (HUB). En estos verticales la **imagen es el producto** y manda el LCP.
+> `imagePipeline(src, opts)` vive en el core (IoC) y corre en el build. Lee `tenant_config.json` (imageFormats, imageGeoExif).
+
+## 0. Las 3 ganancias (una pasada, tres beneficios)
+1. **Velocidad (CWV/LCP)**: formatos modernos (WebP/AVIF) pesan ~30-50% menos → LCP baja → mejor ranking + UX.
+2. **SEO de imagen**: `alt` real + `ImageObject` + nombres de archivo descriptivos → Google Images + rich results.
+3. **Señal local (opcional)**: EXIF geo en las fotos (lat/lng del local) = señal menor de local SEO.
+
+## 1. Generación en el build (Sharp o equivalente)
+```js
+// imagePipeline(src, { formats:['webp','avif'], widths:[400,800,1200], geo }) -> { variants, imageObject }
+import sharp from 'sharp';
+for (const w of widths) for (const fmt of cfg.imageFormats) {
+  await sharp(src).resize({ width: w, withoutEnlargement: true })   // ⛔ NUNCA upscaling
+                  [fmt]({ quality: fmt === 'avif' ? 50 : 75 }).toFile(out(src, w, fmt));
+}
+```
+**REGLA DURA (lección §95-§97 de Altorra)**: el optimizer **NO hace upscaling** → una variante grande de un
+original chico NO se genera. **Antes de poner una variante en `srcset`, verifica que el archivo EXISTE físicamente**
+(referenciar una variante inexistente = imagen rota). El SSG debe emitir solo las variantes realmente generadas.
+
+## 2. Markup que emite (en el HTML del build)
+```html
+<picture>
+  <source type="image/avif" srcset="/img/foto-400.avif 400w, /img/foto-800.avif 800w" sizes="(max-width:600px) 100vw, 50vw">
+  <source type="image/webp" srcset="/img/foto-400.webp 400w, /img/foto-800.webp 800w" sizes="...">
+  <img src="/img/foto-800.jpg" width="800" height="600" alt="<alt REAL>"
+       loading="lazy" decoding="async" fetchpriority="auto">  <!-- LCP: loading="eager" + fetchpriority="high" -->
+</picture>
+```
+- **`width`+`height` SIEMPRE** (mata CLS). · **`loading="lazy"`+`decoding="async"`** below-fold; el **LCP** (hero/
+  1ª foto de la ficha) = `fetchpriority="high"` + sin lazy. · **`alt` real y descriptivo** (cero-demo: "anillo de
+  compromiso oro 18k diamante 0.5ct" > "imagen1"). · `<picture>` con fallback JPG para navegadores viejos.
+
+## 3. ImageObject (schema) + feeds/OG
+```jsonc
+{ "@type":"ImageObject", "contentUrl":"<absoluta https>", "caption":"<alt>",
+  "exifData": [ /* si imageGeoExif: GeoCoordinates */ ] }
+```
+- Las URLs de imagen para **OG** (`og:image`) y **feeds** (`image_link`) deben ser **absolutas https** (los bots/
+  destinos no resuelven relativas). El pipeline expone la URL absoluta vía el core.
+
+## 4. Reglas duras
+- NUNCA upscaling · verificar existencia física de cada variante antes de referenciarla · `alt` real (no relleno) ·
+  `width`/`height` siempre · LCP marcado (eager+high), el resto lazy · imágenes absolutas para OG/feeds.
+
+## ✅ Checklist
+- [ ] WebP/AVIF + fallback generados (sin upscaling; variantes existen físicamente).
+- [ ] `<picture>`/`srcset` + `width`/`height` + lazy/async (LCP = eager+fetchpriority high).
+- [ ] `alt` real y descriptivo por imagen (cero-demo) · `ImageObject` con contentUrl absoluta.
+- [ ] og:image / feed image_link = URL absoluta https.
+- [ ] (Opcional) EXIF geo si `imageGeoExif` y el dueño lo autoriza.

--- a/skills/maps-gbp-local/SKILL.md
+++ b/skills/maps-gbp-local/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: maps-gbp-local
+description: Rankear #1 en el local pack de Google Maps / Google Business Profile (GBP) para un negocio con ubicación (joyería, concesionario, inmobiliaria) — donde se gana o pierde la mayoría del tráfico local de alta intención. Úsala al optimizar la presencia local de cualquier proyecto del paquete de visibilidad: los 3 ejes (relevancia = categoría principal específica + secundarias reales + perfil 100%; distancia = no controlable; prominencia = velocidad/recencia de reseñas + respuestas 24-48h + fotos frescas + citaciones), el NAP maestro (un formato canónico idéntico en sitio/JSON-LD/GBP/directorios/redes), la plantilla LocalBusiness→subtipo (address+geo+openingHours+sameAs+aggregateRating de reseñas REALES), answer capsules 40-60 palabras + FAQPage, y distinguir lo OPERATIVO (lo hace el dueño en GBP) de lo CODIFICABLE (schema/robots/API). Reglas duras: cero-demo (NUNCA aggregateRating inventado, categorías falsas, NAP inconsistente), Colombia (+57 E.164, addressCountry CO, festivos). Triggers — "aparecer en Maps", "local pack", "Google Business Profile/GBP", "reseñas", "NAP", "negocio local en Google", "LocalBusiness schema", "que me encuentren en el mapa". Lee `tenant_config.json` (nap, sameAs, vertical). Pareja de `semantic-schema-aeo`.
+---
+
+# 📍 Maps / GBP Local — ganar el local pack #1
+
+> Parte del paquete de visibilidad (HUB). El local pack (3 resultados con mapa) capta la intención local más
+> caliente. Lee `tenant_config.json` (nap, vertical, sameAs). Datos de GBP (dirección/teléfono/horarios/coords) = ⛔ del dueño.
+
+## 0. Los 3 ejes (qué controlas)
+1. **Relevancia** (controlable): **categoría principal específica** (no genérica) + secundarias REALES + perfil
+   GBP 100% completo + servicios/productos + descripción con keywords naturales.
+2. **Distancia** (NO controlable): proximidad del que busca. No la peleas; la compensas con relevancia+prominencia.
+3. **Prominencia** (controlable, el diferenciador): **velocidad y recencia de reseñas**, respuestas a TODAS las
+   reseñas en 24-48h, **fotos frescas mensuales**, citaciones (directorios), señales web (tu SEO también suma aquí).
+
+## 1. NAP maestro (la base — un solo formato canónico)
+Define UN formato exacto de Nombre·Dirección·Teléfono y úsalo **idéntico** en: sitio web · JSON-LD `LocalBusiness` ·
+GBP · directorios (PaginasAmarillas, sectoriales) · redes. **Inconsistencia de NAP = confunde a Google = baja
+prominencia.** Vive en `tenant_config.nap` (single source). Teléfono **+57 E.164**, `addressCountry: CO`.
+
+## 2. Schema LocalBusiness (lo CODIFICABLE — en el HTML del build)
+```jsonc
+{ "@context":"https://schema.org",
+  "@type":"AutoDealer",                         // subtipo por vertical: JewelryStore | AutoDealer | RealEstateAgent
+  "name":"<nap.legalName>", "image":"<logo>", "url":"<baseUrl>",
+  "telephone":"+57XXXXXXXXXX", "priceRange":"$$",          // opcional, real
+  "address":{ "@type":"PostalAddress", "streetAddress":"...", "addressLocality":"Cartagena",
+              "addressRegion":"Bolívar", "addressCountry":"CO" },
+  "geo":{ "@type":"GeoCoordinates", "latitude":<lat>, "longitude":<lng> },
+  "openingHoursSpecification":[ /* de nap.openingHours; contemplar festivos CO */ ],
+  "sameAs":[ /* redes REALES */ ],
+  "aggregateRating":{ "@type":"AggregateRating", "ratingValue":"4.8", "reviewCount":"37" }  // SOLO si reseñas REALES
+}
+```
+**`aggregateRating` SOLO con reseñas reales** (de GBP/web). Inventarlo = spam penalizado. Si no hay, omitir.
+
+## 3. Answer capsule + FAQ (para Maps + AEO local)
+En la home/landing: cápsula de respuesta **40-60 palabras** ("¿Quién es X? ¿Dónde? ¿Qué vende?") + FAQ visible +
+`FAQPage`. Es lo que la IA y el snippet local extraen. `robots.txt` habilita los bots IA (ver `semantic-schema-aeo`).
+**Landing por ciudad** si operas en varias (una página real por ciudad, no doorway pages).
+
+## 4. OPERATIVO (lo hace el dueño en GBP — la skill da la lista, no lo ejecuta)
+- Reclamar/verificar el GBP · categoría principal correcta · perfil 100% (horarios, fotos, productos, atributos).
+- **Pedir reseñas** sistemáticamente (link directo) + **responder todas** en 24-48h con keywords naturales
+  (categoría+ciudad: "gracias por confiar en nuestro taller en Cartagena").
+- **Inventario en GBP**: publicar productos/vehículos (GBP Products / Vehicle inventory) — empuja datos a Google.
+- Fotos nuevas cada mes · posts/ofertas.
+
+## 5. Antipatrones (cero-demo / no hagas)
+Keyword-stuffing en el NOMBRE del negocio (solo el nombre real) · categorías falsas · **aggregateRating inventado** ·
+NAP inconsistente · reseñas compradas/falsas (baneo) · doorway pages por ciudad sin contenido real.
+
+## ✅ Checklist
+- [ ] `tenant_config.nap` define el NAP maestro · idéntico en web/JSON-LD/GBP/directorios.
+- [ ] `LocalBusiness`→subtipo en el HTML del build (curl+grep) con address+geo+openingHours+sameAs.
+- [ ] `aggregateRating` solo si hay reseñas reales · teléfono +57 E.164 · addressCountry CO.
+- [ ] Answer capsule 40-60 palabras + FAQPage · robots habilita bots IA.
+- [ ] (Operativo dueño) GBP verificado, categoría correcta, perfil 100%, flujo de reseñas + respuestas 24-48h.

--- a/skills/product-feeds/SKILL.md
+++ b/skills/product-feeds/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: product-feeds
+description: Generar feeds de producto/inventario en el BUILD para EMPUJAR tu catálogo a Google y portales en vez de esperar el rastreo — la palanca de visibilidad #1 que casi todos olvidan. Úsala cuando un negocio con catálogo (joyería, concesionario, inmobiliaria) quiere que su inventario aparezca en superficies de alto valor: Google Merchant Center (productos/joyas → Shopping/free listings), Google Vehicle Ads + Local Inventory (autos), portales inmobiliarios CO (FincaRaíz/Metrocuadrado). El feed se genera como una salida MÁS del mismo build SSG (consume la misma data Firestore + tenant_config), por vertical. Reglas duras: solo ítems `status:published`, datos REALES (cero-demo — precio/disponibilidad reales o el campo apropiado para "bajo consulta"), formato exacto que exige cada destino (TSV/XML), IDs estables = slug/codigoUnico inmutable. Triggers — "feed de productos", "Google Merchant Center", "Shopping", "vehicle ads", "local inventory", "publicar inventario en FincaRaíz/Metrocuadrado", "empujar catálogo a Google", "free product listings". Lee `tenant_config.json` (vertical, feeds[], nap). Salida del mismo build que `ssg-static-prerender`. NUEVA en el paquete (gap real: la mayoría no tiene feeds).
+---
+
+# 📤 Product Feeds — empujar el catálogo (no esperar el rastreo)
+
+> Parte del paquete de visibilidad (HUB). Empujar datos > esperar que Google rastree. El feed = otra salida
+> del MISMO build SSG (misma data + `tenant_config`). `buildFeed(feedType, items, config)` vive en el core (IoC).
+> Qué feeds genera cada repo lo dice `tenant_config.feeds[]`. Cuentas (Merchant/portales) = ⛔ del dueño.
+
+## 0. Por qué (el gap)
+El SSG hace tu sitio rastreable; el **feed te mete en superficies que NO rastrean tu sitio**: Google Shopping/
+free listings, Vehicle Ads, portales inmobiliarios. Es push directo de inventario estructurado → más alcance
+con la misma data. Altorra/Bersaglio hoy NO tienen feeds = oportunidad sin tocar.
+
+## 1. Feeds por vertical (qué generar según `tenant_config.feeds`)
+| Vertical | Destino | Formato | Campos núcleo |
+|---|---|---|---|
+| **JewelryStore** | Google Merchant Center (free listings + Shopping) | TSV o XML (Google Product) | `id`, `title`, `description`, `link`, `image_link`, `price`*, `availability`, `brand`, `google_product_category`, `mpn` |
+| **AutoDealer** | Google Vehicle Ads + Local Inventory | feed Vehicle | `vehicle_id`(VIN/codigoUnico), `make`, `model`, `year`, `price`*, `mileage`, `condition`, `image[]`, `vehicle_option`, `dealer{name,address}` |
+| **RealEstateAgent** | FincaRaíz / Metrocuadrado (portales CO) | XML/CSV del portal | `referencia`, `tipo`, `operacion`(venta/arriendo), `precio`*, `area`, `habitaciones`, `baños`, `ciudad`, `barrio`, `fotos[]` |
+
+`*` precio: REAL si `priceDisplay:"real"`; si "bajo consulta" usa el campo/estado que el destino permita (algunos
+exigen precio → o lo das real, o no listas ese ítem en ese feed; **no inventes un precio**).
+
+## 2. Generación (en el build — `buildFeed` del core, IoC)
+```js
+// el tenant orquesta: misma data Firestore que el SSG, filtrada a published
+const items = allItems.filter(i => i.status === 'published');
+for (const feedType of cfg.feeds) {
+  const feedStr = buildFeed(feedType, items, cfg);   // core: mapea vertical→formato del destino, escapeXml
+  bakeIntegrity(feedStr, MIN_FEED_BYTES);            // guard: feed vacío/roto NO se publica
+  writeFile(`feeds/${feedType}.xml`, feedStr);       // se sube a GH Pages; el destino lo lee por URL
+}
+```
+- **IDs estables** = `slug`/`codigoUnico` inmutable (si el id cambia, el destino crea un duplicado/pierde histórico).
+- **`image_link`** absoluto (https) — el feed exige URLs completas. (Las imágenes vienen de `image-pipeline`.)
+- **escapeXml** en todo campo de texto (campos editables de CMS = riesgo de romper el XML).
+
+## 3. Reglas duras
+- Solo `status:published`. · **Cero-demo**: precio/disponibilidad/specs REALES; "bajo consulta" → estado correcto,
+  nunca precio inventado. · Formato EXACTO del destino (un campo mal nombrado → el feed se rechaza entero).
+- Cumplir las políticas del destino (Merchant: imágenes sin marca de agua, precio = el del landing, etc.).
+- El feed se regenera en cada build (on-push + diario) → siempre fresco; el destino re-fetcha por URL.
+
+## ✅ Checklist
+- [ ] `tenant_config.feeds[]` define los destinos por vertical.
+- [ ] `buildFeed` mapea vertical→formato exacto del destino (TSV/XML) con `escapeXml`.
+- [ ] Solo published · IDs estables (slug/codigoUnico) · `image_link` absolutos.
+- [ ] bake-integrity del feed (no publicar feed vacío/roto) · precio real o estado "consulta" (cero-demo).
+- [ ] (Operativo dueño) cuenta Merchant/portal creada + feed dado de alta por URL + políticas cumplidas.

--- a/skills/search-console-setup-y-diagnostico/SKILL.md
+++ b/skills/search-console-setup-y-diagnostico/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: search-console-setup-y-diagnostico
+description: Dar de alta Google Search Console (GSC) y diagnosticar por qué un sitio "no sale en Google" — la herramienta gratis que dice qué indexó Google, con qué queries apareces y qué está roto. Úsala al lanzar/auditar la indexación de cualquier sitio del paquete de visibilidad: alta (propiedad Dominio + TXT DNS, fallback HTML/meta), checklist pre-deploy que el SSG ya garantiza (title/desc únicos, canonical autorreferencial, JSON-LD válido, robots con Sitemap:, cero noindex residual), envío de sitemap + URL Inspection en home+2-3 fichas (sembrar), el ÁRBOL de diagnóstico "no aparezco" (site: → URL Inspection → Page Indexing → Manual Actions/Security → latencia), el bucle mensual (Performance: CTR bajo+impresiones altas→reescribir meta; striking distance pos 8-20; Rich Results; CWV), y la API GSC (service account + Action programada) para histórico >16 meses. Regla clave: GSC NO indexa automáticamente vía API; es diagnóstico+envío. Triggers — "no aparezco en Google", "Search Console", "indexación", "enviar sitemap", "por qué no me indexa", "URL Inspection", "cobertura/coverage", "queries de búsqueda", "rich results errores". Lee `tenant_config.json` (baseUrl, gscVerification). Cuenta GSC del dueño = ⛔.
+---
+
+# 🔎 Search Console — alta + diagnóstico "no salgo en Google"
+
+> Parte del paquete de visibilidad (HUB). GSC = ojos de Google sobre tu sitio (gratis). NO indexa por ti
+> (no hay "indexación automática vía API") — verifica, envía, diagnostica. Lee `tenant_config.json` (baseUrl).
+
+## 1. Alta (una vez)
+- Propiedad tipo **Dominio** (cubre http/https/www/subdominios) → verificación **TXT en DNS** (la más robusta).
+  Fallback: propiedad de prefijo-URL + archivo HTML o meta-tag (`tenant_config.gscVerification`).
+- Vincular **GA4 ↔ GSC** (y Google Ads) para cruzar datos.
+
+## 2. Pre-deploy (lo GARANTIZA el SSG — verifícalo antes de pedir indexación)
+- [ ] title + meta description **únicos** por página (no duplicados).
+- [ ] **canonical autorreferencial** correcto (cada ficha apunta a sí misma).
+- [ ] JSON-LD **válido** (Rich Results Test sin errores).
+- [ ] `robots.txt` con `Sitemap: <baseUrl>/sitemap.xml` + habilita bots IA.
+- [ ] **CERO `noindex` residual** (el bug clásico: un `noindex` global de "en construcción" que nadie quitó →
+  Google obedece y NO indexa NADA). Búscalo: `curl -s <url> | grep -i noindex` debe salir vacío.
+
+## 3. Sembrar la indexación (acelera el descubrimiento)
+- **Enviar el sitemap** en GSC (Sitemaps → `sitemap.xml`).
+- **URL Inspection** en la home + 2-3 fichas clave → "Solicitar indexación" (empuja a Google a rastrear ya).
+- No esperes pasivo: el sitemap + inspection siembran; el resto Google lo descubre por links internos.
+
+## 4. 🌳 Árbol de diagnóstico "no aparezco en Google" (en orden)
+1. **`site:tudominio.com`** en Google → ¿0 resultados? → Google no tiene NADA indexado → ve a 2/3.
+2. **URL Inspection** de la URL que falta → ¿"URL no está en Google"? mira el motivo:
+   - "Excluida por `noindex`" → quita el noindex (paso 2 de arriba).
+   - "Página alternativa con canonical adecuado" → tu canonical apunta a otra URL (revisa).
+   - "Rastreada, no indexada" → contenido fino/duplicado → mejora el contenido único.
+   - "Descubierta, no rastreada" → presupuesto de rastreo/latencia → sitemap + links internos + paciencia.
+3. **Page Indexing** (Coverage) → patrones de exclusión masiva (noindex, 404, redirect, canonical).
+4. **Manual Actions / Security** → ¿penalización manual o hackeo? (raro pero fatal — descártalo).
+5. **Latencia**: un sitio nuevo tarda **días-semanas** en indexar. Si todo lo anterior está OK → es tiempo.
+
+## 5. Bucle mensual (de diagnóstico a mejora)
+- **Performance**: queries con **muchas impresiones + CTR bajo** → reescribir title/meta (el snippet no atrae).
+  **Striking distance** (posición 8-20) → empujar esas páginas (más contenido/links internos) para subir a la pág 1.
+- **Rich Results / Enhancements**: cero errores (los structured-data de la skill `semantic-schema-aeo`).
+- **Core Web Vitals** (informe CWV): verde (móvil primero).
+
+## 6. API GSC (avanzado, opcional, gratis)
+Service account (GCP) + GitHub Action programada → exportar el histórico de Performance (GSC borra >16 meses).
+Útil para tendencias largas. **No indexa**; solo lee datos. (La service account = ⛔ del dueño.)
+
+## ✅ Checklist
+- [ ] Propiedad Dominio verificada (TXT DNS) · GA4↔GSC vinculados.
+- [ ] Pre-deploy verde (titles únicos, canonical, JSON-LD, robots+Sitemap, CERO noindex).
+- [ ] Sitemap enviado + URL Inspection en home+2-3 fichas.
+- [ ] Árbol de diagnóstico documentado (si no aparece, seguir los 5 pasos en orden).
+- [ ] Bucle mensual agendado (Performance/Rich Results/CWV).

--- a/skills/semantic-schema-aeo/SKILL.md
+++ b/skills/semantic-schema-aeo/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: semantic-schema-aeo
+description: El cerebro semántico de la visibilidad — qué structured data (JSON-LD) inyectar por tipo de página + cómo ser CITADO/RECOMENDADO #1 por buscadores e IA (AEO). FUSIÓN deliberada de SEO-técnico (schema) + AEO (answer-engine) porque ambos viven en el mismo `<head>` y separarlos colisiona. Úsala al construir `buildSchema()` del core o al decidir el schema/meta de un sitio: Product/Offer/AggregateRating/Review/Organization/LocalBusiness/BreadcrumbList/FAQPage/Article/Person/ImageObject con sus props requeridas vs recomendadas + plantillas parametrizables por vertical (JewelryStore/AutoDealer/RealEstateAgent). Incluye CWV 2026 (LCP/INP/CLS), E-E-A-T, y el playbook AEO (=20% código / 80% off-page: el código referencia el consenso externo —sameAs/reseñas/FAQ citable—, NO lo genera). Regla dura: schema en el HTML del build (curl+grep), cero-demo (NUNCA AggregateRating/sameAs/reseñas inventadas = spam penalizado), NAP maestro. Triggers — "qué schema pongo", "structured data", "rich results", "que la IA me recomiende", "AEO", "FAQ schema", "aparecer en AI Overviews/ChatGPT/Perplexity", "Organization/LocalBusiness JSON-LD". Pareja de `ssg-static-prerender`. Lee `tenant_config.json`.
+---
+
+# 🧠 Semantic Schema + AEO — structured data + ser citado por la IA
+
+> FUSIÓN (decisión verificada: structured-data + answer-engine viven en el mismo `<head>`). Parte del
+> paquete de visibilidad (HUB). El código emite el JSON-LD (la skill `ssg-static-prerender` lo hornea);
+> el **playbook off-page** lo ejecuta el dueño/marketing. Lee `tenant_config.json` (vertical, nap, sameAs, priceDisplay).
+
+## 0. Las dos verdades
+1. **On-page (20%)**: el schema/meta correcto en el HTML del build → elegibilidad para rich results + materia
+   prima para que la IA entienda tu entidad. Necesario, NO suficiente.
+2. **Off-page (80%) — el driver real del AEO**: la IA recomienda lo que el **CONSENSO externo** repite (reseñas,
+   directorios, menciones, Knowledge Graph). El código REFERENCIA ese consenso (`sameAs`, FAQ citable, formato
+   respuesta-primero); **no lo genera**. Por eso esta skill = parte-código + PLAYBOOK operativo. No prometas
+   "ranking-IA solo con código".
+
+## 1. Structured data por tipo de página (checklist — props REQUERIDAS vs recomendadas)
+> Emite SOLO campos con dato real (schema condicional). `@context:"https://schema.org"`. Verificar en Rich Results Test.
+
+| Página | Tipo(s) JSON-LD | Requeridas | Recomendadas |
+|---|---|---|---|
+| Ficha de ítem | `Product` (o `Car`/`Residence` por vertical) + `Offer` | name, image, description, offers{price\|priceCurrency\|availability} | brand, sku, `aggregateRating`*, `review`*, additionalProperty |
+| Home/entidad | `Organization` + `LocalBusiness`→subtipo | name, url, logo | `sameAs`, address, geo, telephone, openingHours, `aggregateRating`* |
+| Listado/categoría | `BreadcrumbList` + `ItemList` | itemListElement | — |
+| FAQ / respuesta | `FAQPage` (Q&A visibles en la página) | mainEntity[{Question,acceptedAnswer}] | — |
+| Journal/blog | `Article` + `Person` (autor) | headline, datePublished, author | `dateModified` (frescura), image |
+| Imagen | `ImageObject` | contentUrl | caption, `exifData` (geo, opcional) |
+
+`*` **AggregateRating/Review SOLO si hay reseñas REALES.** Inventarlas = structured-data spam → **acción manual /
+baneo algorítmico**. Cero-demo absoluto. Si no hay reseñas → omitir el campo (no poner 5.0 ficticio).
+
+## 2. Plantilla JSON-LD parametrizable (el corazón de `buildSchema(vertical, item)`)
+```js
+// pseudo del core (funciones puras). availability: priceDisplay "consulta" -> PreOrder/InStock sin price.
+function buildSchema(vertical, x, cfg) {
+  const TYPE = { JewelryStore: ['JewelryStore','Product'], AutoDealer: ['AutoDealer','Car'], RealEstateAgent: ['RealEstateAgent','Residence'] }[vertical];
+  const offer = cfg.priceDisplay === 'real' && x.price
+    ? { '@type':'Offer', price:String(x.price), priceCurrency:'COP', availability:'https://schema.org/InStock' }
+    : { '@type':'Offer', availability:'https://schema.org/PreOrder', priceSpecification:{ '@type':'PriceSpecification', valueAddedTaxIncluded:true } }; // "bajo consulta"
+  return { '@context':'https://schema.org', '@type':TYPE[1], name:x.title, image:x.images,
+           description:x.desc, brand:x.brand, offers:{ ...offer, seller:{ '@type':TYPE[0], name:cfg.brandName } },
+           additionalProperty: verticalProps(vertical, x) };  // quilates|kilometraje|area_m2 según vertical
+}
+```
+Detalle de `additionalProperty` por vertical + `LocalBusiness`/`Organization` con `sameAs` → usa `tenant_config`.
+**Gate legal**: campos sensibles (VIN/placa de terceros, datos personales) solo con base legal (Habeas Data CO).
+
+## 3. AEO — el playbook off-page (lo que el código NO hace)
+- **Entidad consistente**: `Organization`+`LocalBusiness` + `sameAs` COMPLETO (redes REALES del dueño) + NAP
+  idéntico en toda superficie + Wikidata/Google Knowledge Panel donde aplique.
+- **Formato citable** (en la página, visible): respuesta-directa **<150 palabras** arriba, subtítulos-pregunta,
+  tablas, FAQ visible + `FAQPage`. La IA cita lo que puede extraer fácil.
+- **Autoridad/consenso**: GBP al 100%, directorios sectoriales, **reseñas reales con keywords categoría+ciudad**,
+  Digital PR/menciones. (Esto es trabajo del dueño/marketing — la skill da la lista, no lo ejecuta.)
+- **Rastreo IA**: `robots.txt` habilita GPTBot/PerplexityBot/Google-Extended/ClaudeBot/BingBot (de `tenant_config.robotsAiBots`).
+- **Frescura**: `dateModified` trimestral en páginas clave. **Medición**: 20-30 consultas objetivo, auditoría
+  semanal en ChatGPT/Perplexity/Gemini/AI Overviews (¿te mencionan? ¿con qué dato?).
+
+## 4. CWV 2026 + E-E-A-T (señales técnicas que sostienen el ranking)
+- **Core Web Vitals (p75 CrUX)**: LCP < 2.5s · INP < 200ms · CLS < 0.1. Recetas: **INP** = partir/diferir JS,
+  evitar long tasks; **CLS** = `width`/`height` en img + `font-display:swap`; **LCP** = preload + critical CSS +
+  `fetchpriority="high"` SOLO en el LCP. (Encaja con la doctrina de performance del proyecto.)
+- **E-E-A-T**: página Nosotros/autor (`Person`), políticas/garantías, reseñas reales. Demuestra experiencia real.
+
+## 5. Red-team (errores que HUNDEN el ranking — evítalos)
+AggregateRating inventado · sameAs a redes que no existen · keyword-stuffing · schema que no matchea el contenido
+visible (Google lo cruza) · `noindex` residual · canonical roto · NAP inconsistente · schema solo por JS (invisible al bot).
+
+## ✅ Checklist de cierre
+- [ ] `curl -s <url> | grep 'application/ld+json'` muestra el JSON-LD (en el build, no JS).
+- [ ] Rich Results Test sin errores · cero AggregateRating/review sin reseñas reales.
+- [ ] `sameAs` solo con redes REALES (o vacío) · NAP idéntico web↔schema↔GBP.
+- [ ] Respuesta-directa <150 palabras + FAQ visible + `FAQPage` en páginas clave.
+- [ ] robots habilita los bots IA · `dateModified` fresco.

--- a/skills/ssg-static-prerender/SKILL.md
+++ b/skills/ssg-static-prerender/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: ssg-static-prerender
+description: Hornear HTML estático REAL por ítem en el BUILD para hosting estático (GitHub Pages, etc.) — la base de TODA la visibilidad (SEO·AEO·OG-social). Úsala cuando un sitio sirve fichas/piezas/propiedades desde una BD pero el HTML que llega al bot/LLM está vacío (SPA que hidrata por JS): los crawlers de Google/redes/IA NO ejecutan JS, así que schema/meta/contenido DEBEN existir en el HTML del build. Genera, en GitHub Actions on-push+diario, una página por ítem `status:published` con canonical/title/meta/OG/Twitter/JSON-LD/<noscript>, + sitemap.xml, con guards anti-fail-silent (REQUIRED_ANCHORS, bake-integrity, SSG_SELFTEST, safeJsonLd). Portable por `tenant_config.json` (vertical JewelryStore/AutoDealer/RealEstateAgent, colecciones, templates). Arquitectura HUB IoC: el core = funciones puras; cada tenant orquesta. Triggers — "hornear HTML en el build", "SSG", "prerender estático", "mi schema solo lo ve Googlebot/no aparece en curl", "OG no carga en WhatsApp/redes", "indexar fichas de la BD". Parte del paquete de visibilidad (HUB Altorra). NO uses para SSR dinámico (Next/Nuxt server) ni para una página única estática sin BD.
+---
+
+# 🏭 SSG Static Prerender — hornear HTML real en el build (la base de la visibilidad)
+
+> Destilado de la fábrica SSG verificada de Altorra Cars (`scripts/generate-vehicles.mjs`). Portable a
+> cualquier proyecto vía `tenant_config.json`. Parte del **paquete de visibilidad** (HUB Altorra).
+> Arquitectura + esquema de config → `references/tenant-config.md` · contrato del core IoC → `references/ioc-core-contract.md`.
+
+## 0. La ley (por qué existe)
+Hosting estático = sin SSR. Los bots sociales (WhatsApp/Facebook/X) y los crawlers de **Google + LLMs
+(GPTBot/PerplexityBot/Google-Extended)** **NO ejecutan JavaScript**. Si tu `<head>`/schema/contenido se
+inyecta por JS en runtime → el bot ve una página vacía → **no indexas, no apareces, el OG no carga**.
+**REGLA DURA**: el schema/meta/contenido clave SIEMPRE en el **HTML del build**, verificable por
+`curl -s URL | grep`, NUNCA solo por JS runtime. Esta skill hornea ese HTML.
+
+## 1. Arquitectura IoC (la corrección de Gemini, adoptada — el core NO toca el template)
+El **Core Library** compartido (`scripts/visibility-core/`) = **funciones PURAS**, jamás lee un template:
+- `validateTenant(config)` → fail-fast anti-contaminación (aborta si el vertical no matchea).
+- `buildSchema(vertical, data)` → string JSON-LD (vía `safeJsonLd`).
+- `buildSitemap(entries)` → string XML. · `safeJsonLd`, `escapeHtml/Attr/Xml` (primitivas de seguridad).
+**Cada tenant** tiene su `tenant-build.mjs` (NO compartido): lee SU template, **pide piezas al core**, las
+inyecta donde quiera (`.replace()`), corre bake-integrity, escribe. Así el template puede diferir por proyecto
+sin acoplarse al core; un cambio no-breaking del core no toca ningún template. (Distribución del core = **D′
+vendored + `VERSION`**, sin lockstep; reusa la replicación-kernel del HUB; migrar a NPM luego = re-empaque.)
+
+## 2. La receta (qué hace `tenant-build.mjs`, paso por paso)
+1. **`connectDb()`**: lee la BD en el build — Admin SDK si hay `FIREBASE_SA_KEY` (lectura autenticada → permite
+   endurecer reglas + drafts), si no SDK cliente anónimo (fallback, cero regresión). Interfaz uniforme.
+2. **`validateTenant(config)`** (del core): ABORTA si el vertical/campos no corresponden (§5 anti-contaminación).
+3. **Por cada ítem `status:published`** (gate anti-indexar pruebas/borradores): parte del template y por
+   `.replace()` inyecta en anclas declaradas: `<base href="/">`, `<link canonical>`, `<title>`, `<meta description>`,
+   **OG** (og:url/title/description/image), **Twitter card**, **JSON-LD** (`buildSchema(vertical,data)`), y un
+   **`<noscript>`** con el contenido clave (h1/img/precio/specs) para crawlers sin JS. Inyecta
+   `<script>window.PRERENDERED_<TYPE>_ID = safeJsonLd(id)</script>` para que el JS hidrate sin query param.
+4. **Guards** (§3). 5. **`buildSitemap()`** → `sitemap.xml` + `data/*-slugs.json`.
+
+## 3. Guards anti-fail-silent (NO negociables — una página rota NUNCA llega a prod)
+- **`REQUIRED_ANCHORS`** (por-tenant, en `tenant-build.mjs`): array de marcadores que el template DEBE tener;
+  si falta uno → **THROW ruidoso** (no 27 páginas con SEO roto en silencio).
+- **bake-integrity**: cada página horneada DEBE cerrar `</html>` y pesar ≥ `MIN_BAKE_BYTES` (ej. 5000); si no →
+  **ABORTA el build** (el workflow no commitea → prod queda en el último build bueno). Patrón fail-loud.
+- **`SSG_SELFTEST`** (gate DEV con mocks): inyecta payloads de breakout (`</script>`, `"><img onerror>`) y
+  verifica que `safeJsonLd`/`escapeAttr` los neutralizan → gate anti-stored-XSS con dientes (no teatro).
+- **`safeJsonLd(obj)`**: neutraliza `</script>` + U+2028/U+2029 en sinks JSON-LD/PRERENDERED. **`escapeAttr`/
+  `escapeHtml`/`escapeXml`** por contexto (defensa-en-profundidad ante campos editables de un CMS).
+
+## 4. Reglas duras (cruzan todo el paquete)
+- **Schema/meta en el HTML del build** (verificable `curl+grep`), jamás solo JS. · **status:published** gatea
+  horneado+indexación (no indexar "PRUEBA"). · **slug inmutable** (slugify una vez + sufijo del id; sin SSR no
+  hay 301 dinámico — cambiar slug = romper links/ranking). · **cero-demo**: solo data REAL (nunca rating/sameAs/
+  origen inventado). · `sitemap`: lastmod **FIJO** en estáticas (Google ignora si todo es "hoy"), `updatedAt` en ítems.
+- Corre en **GitHub Actions** on-push (deploy) + diario (refresca lastmod/altas) — repos públicos = Actions gratis.
+
+## 5. Anti-contaminación por vertical (`validateTenant`, fail-fast — clave del HUB multi-proyecto)
+Validador **a mano** (sin Zod — build node-plano, dep-free, estilo REQUIRED_ANCHORS): asegura que `config.vertical`
+∈ {JewelryStore, AutoDealer, RealEstateAgent} y que NO emite campos de otro vertical (joya con `kilometraje`/VIN,
+o auto con `quilates` → THROW antes del SSG → el Action ABORTA). Agregar un proyecto nuevo = nuevo `tenant_config`
++ correr; el core no cambia. Detalle de campos por vertical → `references/tenant-config.md`.
+
+## 6. Adopción en un proyecto (checklist)
+- [ ] `tenant_config.json` en la raíz (vertical, colecciones, template paths, `MIN_BAKE_BYTES`, baseUrl) → `references/tenant-config.md`.
+- [ ] `scripts/visibility-core/` vendored (funciones puras + `VERSION`) — el HUB lo provee/propaga.
+- [ ] `scripts/tenant-build.mjs` (orquestador propio: connectDb → validateTenant → loop published → inyectar → guards → sitemap).
+- [ ] Templates con las anclas que declara `REQUIRED_ANCHORS`.
+- [ ] Workflow `.github/workflows/build-ssg.yml` on-push + cron diario (`npm run generate`).
+- [ ] Campo `status` por ítem en la BD (`published|draft|archived`) + `slug` inmutable + `updatedAt`.
+- [ ] Verificación EN VIVO: `curl -s <url-ficha> | grep -E 'application/ld\+json|og:title|<title>'` muestra el contenido (no vacío).
+
+> Pareja natural: `semantic-schema-aeo` (qué schema inyectar), `image-pipeline` (las imágenes que el `<noscript>`/OG
+> referencian), `product-feeds` (otra salida del mismo build). Crédito de patrón: fábrica SSG de Altorra Cars.

--- a/skills/ssg-static-prerender/agents/seo-auditor.md
+++ b/skills/ssg-static-prerender/agents/seo-auditor.md
@@ -1,0 +1,33 @@
+---
+name: seo-auditor
+description: Auditor read-only de visibilidad (SEO·AEO·schema·local·CWV) que verifica un sitio contra las reglas del paquete de visibilidad del HUB — antes de declarar "ya estamos indexables/optimizados". Recorre el HTML del BUILD + el código + el tenant_config y reporta violaciones con evidencia archivo:línea. Es adversarial y NO edita. Invócalo cuando alguien diga "audita el SEO/visibilidad", "¿está bien el schema?", "¿por qué no indexo?", "revisa antes de lanzar", "chequea el structured data", o como gate antes de pedir indexación. Empareja con las skills `ssg-static-prerender` / `semantic-schema-aeo` / `maps-gbp-local`.
+tools: Read, Grep, Glob, Bash
+---
+
+You are **seo-auditor**, an adversarial read-only auditor of website visibility (SEO/AEO/schema/local/Core Web Vitals) for the HUB visibility package. You REPORT, you never edit. Your job: catch the silent failures that make a site invisible to Google/social/AI crawlers BEFORE launch, by verifying the **built HTML + code + tenant_config** against the package's hard rules.
+
+## What you check (cite evidence: file:line or the exact grep)
+1. **Schema/meta in the BUILD HTML, not JS** (the #1 rule): for representative built pages (the generated item HTML under the outDir, NOT the source template), confirm `<title>`, `<meta name="description">`, canonical, OG (`og:title`/`og:image`/`og:url`), Twitter, and `application/ld+json` are PRESENT as static HTML. Use `grep` on the built files. If they only appear in a JS bundle / are injected at runtime → CRITICAL (crawlers won't see them).
+2. **Cero-demo violations** (penalty risk): grep the schema/data for `aggregateRating`/`review` without real reviews, `sameAs` pointing to non-existent/placeholder socials, invented prices, fake categories. Any fabricated structured-data → CRITICAL (Google manual action risk).
+3. **noindex residual**: grep built pages + robots for `noindex` / `robots: none` / `Disallow: /` that would block indexing. A leftover global noindex is the classic "nothing indexes" bug → CRITICAL.
+4. **status gate**: confirm only `status:published` items were baked (no "PRUEBA"/draft pages in the output / sitemap).
+5. **canonical correctness**: each item's canonical is self-referential and absolute (not pointing elsewhere / not relative).
+6. **NAP consistency**: the NAP (name/address/phone) is identical across the LocalBusiness JSON-LD, the visible HTML, and `tenant_config.nap`. Flag any mismatch (hurts local prominence).
+7. **anti-contamination / vertical**: the emitted schema type matches `tenant_config.vertical` and carries no foreign-vertical fields (JewelryStore with `kilometraje`/VIN, AutoDealer with `quilates`). Flag → the validateTenant gate should have caught it.
+8. **sitemap + robots**: `sitemap.xml` exists, lists published items, lastmod is `updatedAt` (not all "today"); `robots.txt` has `Sitemap:` and enables AI bots (GPTBot/PerplexityBot/Google-Extended).
+9. **Core Web Vitals smells** (static check): images without `width`/`height` (CLS), no `loading="lazy"` below-fold, missing WebP/AVIF, `fetchpriority="high"` on non-LCP, render-blocking JS in `<head>`.
+10. **AEO basics**: a <150-word answer-capsule + visible FAQ + `FAQPage` on key pages; `dateModified` present/fresh.
+
+## Discipline
+- **Verify against the BUILT output, not the source template** — the template can look right while the build is broken (this is exactly the silent failure). If no built output exists yet, say so and audit the source + generator instead, flagging that a build verification is still required.
+- **Quote the evidence** (the grep match, the file:line). A finding without evidence is noise.
+- **Severity**: CRITICAL (invisible/penalized), MAJOR (degraded ranking), MINOR (polish). Default to flagging when unsure — better a false alarm than a silent de-index.
+- You may run read-only `Bash` (grep/find/curl of a public URL if reachable); never edit, deploy, or mutate. If `curl` is sandboxed/unavailable, audit the on-disk built files.
+
+## Output
+1. **Verdict**: READY TO INDEX | NOT READY (with the CRITICAL count).
+2. **Findings table**: `| ID | Severity | Rule | Finding | Evidence (file:line / grep) | Fix |`.
+3. **The single most important fix first** (one line).
+4. If no built HTML was found: say "build not verified — re-run after the SSG build" explicitly.
+
+You are the gate that stops a site from launching invisible. The cruelest bug here is silent: everything looks fine in the browser (JS hydrates it) but the crawler sees an empty page. Hunt that.

--- a/skills/ssg-static-prerender/references/ioc-core-contract.md
+++ b/skills/ssg-static-prerender/references/ioc-core-contract.md
@@ -1,0 +1,55 @@
+# Contrato del Core Library (IoC) — `scripts/visibility-core/`
+
+> El core compartido = **funciones PURAS** (entran datos, salen strings/objetos). **JAMÁS lee un template,
+> jamás toca el FS de un proyecto, jamás hardcodea un nombre de proyecto.** Cada tenant ORQUESTA. Distribución
+> = **D′ vendored**: el HUB (cars-operador) escribe el core canónico y lo replica byte-idéntico a cada repo
+> (`scripts/visibility-core/`), con un `VERSION`; un `brain-check` extendido hashea y AVISA de drift (no aborta —
+> sin lockstep: un repo puede ir atrasado). Migrar a NPM luego = re-empaque (API estable). Build node-plano,
+> ESM vanilla, **cero deps pesadas**.
+
+## API pública (estable — lo que un tenant importa)
+```js
+import {
+  VERSION,                 // string semver del core vendored
+  validateTenant,          // (config) -> void | THROW (exit 1) si vertical/campos no corresponden
+  buildSchema,             // (vertical, entityOrItemData) -> string JSON-LD (ya pasado por safeJsonLd)
+  buildSitemap,            // (entries:[{loc,lastmod}]) -> string XML
+  buildFeed,               // (feedType, items, config) -> string (XML/TSV)  [product-feeds]
+  imagePipeline,           // (srcPath, opts) -> {webp, avif, imageObject}    [image-pipeline]
+  safeJsonLd,              // (obj|string) -> string seguro (neutraliza </script> + U+2028/29)
+  escapeHtml, escapeAttr, escapeXml,   // por contexto
+  bakeIntegrity,           // (html, minBytes) -> void | THROW (no cierra </html> o < minBytes)
+} from './visibility-core/index.mjs';
+```
+
+## Lo que el tenant hace (NO el core) — `tenant-build.mjs`
+```js
+import cfg from '../tenant_config.json' assert { type: 'json' };
+validateTenant(cfg);                               // 1. fail-fast anti-contaminación
+const items = (await connectDb(cfg)).filter(i => i.status === 'published');  // 2. solo published
+for (const it of items) {
+  let html = readTemplate(cfg, it);                // 3. el TENANT lee SU template
+  for (const a of REQUIRED_ANCHORS) if (!html.includes(a)) throw Error('ancla faltante: ' + a);
+  html = html
+    .replace('<!--LD-->', `<script type="application/ld+json">${buildSchema(cfg.vertical, it)}</script>`)
+    .replace('<!--TITLE-->', escapeHtml(title(it)))
+    .replace('<!--OG-->', ogTags(it));             // 4. el TENANT inyecta donde quiera
+  bakeIntegrity(html, cfg.minBakeBytes);           // 5. guard antes de escribir
+  writeOut(cfg, it, html);
+}
+writeFile('sitemap.xml', buildSitemap(entries));   // 6. core produce, tenant escribe
+```
+
+## Por qué IoC (la corrección de Gemini, adoptada)
+Si el core leyera/manipulara el template, el template quedaría acoplado al contrato de anclas del core → cualquier
+cambio en la lógica de inyección obligaría a tocar a mano los HTML de TODOS los proyectos (lockstep). Con IoC el
+core solo produce piezas; el tenant decide dónde van. → templates libres por proyecto + cambios no-breaking del
+core sin tocar templates. **Regla de oro**: si te ves pasando un path de template AL core, lo estás haciendo mal.
+
+## Capas de la arquitectura HUB
+| Capa | Qué | Compartido? | Distribución |
+|---|---|---|---|
+| **Skills** (7 + `seo-auditor`) | playbooks + plantillas (markdown) | sí | replicación de skills (global `~/.claude/skills` + `skills/` por repo) |
+| **Core Library** (JS) | `visibility-core/` funciones puras | sí (byte-idéntico) | **D′ vendored** + `VERSION` + brain-check hash (sin lockstep) |
+| **tenant-build.mjs** | orquestador | **NO** (por proyecto) | vive en cada repo |
+| **templates HTML + tenant_config + data** | por proyecto | **NO** | vive en cada repo |

--- a/skills/ssg-static-prerender/references/onboarding-nuevo-proyecto-al-hub.md
+++ b/skills/ssg-static-prerender/references/onboarding-nuevo-proyecto-al-hub.md
@@ -1,0 +1,43 @@
+# Plantilla — sumar un proyecto NUEVO al HUB de Visibilidad
+
+> Pasos turnkey para incorporar un proyecto (un 5º cerebro / un sitio nuevo) al paquete de visibilidad del
+> HUB (Altorra Cars). **El HUB CONSTRUYE y PROPAGA; cada proyecto IMPLEMENTA** en su propia sesión, con datos
+> REALES del dueño (cero-demo). Las 7 skills + el agente `seo-auditor` son portables vía `tenant_config.json`
+> (cero hardcode de proyecto). Arquitectura → `ioc-core-contract.md` · esquema del config → `tenant-config.md`.
+
+## A. Propagación — la ejecuta el HUB (operador-cars)
+1. **Copiar byte-idéntico** las 7 skills a `skills/` del repo destino:
+   `ssg-static-prerender` (+`references/` +`agents/seo-auditor`) · `semantic-schema-aeo` · `ga4-lead-tracking` ·
+   `maps-gbp-local` · `search-console-setup-y-diagnostico` · `product-feeds` · `image-pipeline`.
+2. El agente `seo-auditor` ya vive **global** en `~/.claude/agents/` (compartido ×proyectos) **y** bundled dentro
+   de `ssg-static-prerender/agents/` (viaja con la skill). NO requiere carpeta `agents/` por-repo.
+3. **Catalogar** en `docs/skills-inventory.md` del destino → sección §Paquete de Visibilidad (reconciliar si el
+   repo ya pre-anotó; **nunca duplicar** la sección).
+4. **L-48**: `git status` ANTES de tocar el git del repo destino (sesiones concurrentes). Commitear SOLO los
+   paths nuevos (JAMÁS `git add -A`); push a la rama de trabajo del repo; el **dueño mergea a `main` en web**.
+
+## B. Implementación — la ejecuta la sesión del proyecto (pide datos al dueño)
+1. `tenant_config.json` en la raíz → esquema en `tenant-config.md`. Fijar `vertical`
+   (`JewelryStore`|`AutoDealer`|`RealEstateAgent`|…). Los campos ⛔ (NAP/redes/GA4/GSC/coords) **los aporta el dueño**.
+2. `scripts/visibility-core/` **vendored** (funciones puras + `VERSION`) — lo provee el HUB (D′, byte-idéntico, sin lockstep).
+3. `scripts/tenant-build.mjs` propio (orquestador IoC: connectDb → `validateTenant` → loop `status:published` →
+   inyectar piezas del core → guards bake-integrity → sitemap). El core NUNCA lee el template; el tenant orquesta.
+4. Templates con las anclas que declara `REQUIRED_ANCHORS`. Campo `status` por ítem + `slug` inmutable + `updatedAt`.
+5. Workflow `.github/workflows/build-ssg.yml` on-push + cron diario (`npm run generate`).
+6. **Gate antes de pedir indexación**: correr el agente `seo-auditor` contra el HTML del BUILD (read-only).
+
+## C. Verticales soportados (gateados por `validateTenant`, anti-contaminación)
+`JewelryStore` (Bersaglio) · `AutoDealer` (Altorra Cars) · `RealEstateAgent` (Inmobiliaria). Un vertical NUEVO =
+añadir su rama en `validateTenant`/`buildSchema` del **core** (cambio del HUB, no del proyecto).
+
+## D. Cero-demo (regla dura — cruza todo el paquete)
+Ningún dato estructurado inventado (`AggregateRating`/`review`/`sameAs`/precio falsos = acción manual de Google).
+Un campo sin dato REAL se **omite**, no se rellena. Vacío > inventado.
+
+## E. Estado de propagación (actualizar al propagar)
+| Proyecto | vertical | 7 skills en `skills/` | tenant_config | implementado |
+|---|---|---|---|---|
+| altorracars (HUB) | AutoDealer | ✅ | pend | pend (fábrica SSG previa existe) |
+| bersaglio | JewelryStore | ✅ (2026-06-25) | pend | pend (sesión bersaglio) |
+| inmobiliaria | RealEstateAgent | ✅ (2026-06-25) | pend | pend |
+| insema | (definir) | ✅ (2026-06-25) | pend | pend |

--- a/skills/ssg-static-prerender/references/tenant-config.md
+++ b/skills/ssg-static-prerender/references/tenant-config.md
@@ -1,0 +1,64 @@
+# `tenant_config.json` — el combustible por proyecto (esquema del HUB)
+
+> UN archivo en la raíz de cada repo. El motor es agnóstico; este config lo personaliza. **CERO hardcode**
+> de nombres de proyecto en las skills/core — todo entra por aquí + env del CI. Agregar un proyecto = nuevo
+> `tenant_config.json` + correr. Lo llena la sesión-implementadora del proyecto con **datos REALES del dueño
+> (cero-demo)**. Todas las skills del paquete de visibilidad leen de aquí.
+
+## Esquema (campos comunes + por vertical)
+```jsonc
+{
+  "project": "altorracars",                 // slug interno (NO se hardcodea en código; viene de aquí)
+  "vertical": "AutoDealer",                  // JewelryStore | AutoDealer | RealEstateAgent  ← gatea schema+validación
+  "baseUrl": "https://altorracars.github.io",
+  "brandName": "ALTORRA CARS",
+  "lang": "es-CO",
+
+  // ── Identidad / entidad (Organization + LocalBusiness) ──
+  "nap": {                                   // NAP MAESTRO — idéntico en web/JSON-LD/GBP/directorios/redes
+    "legalName": "ALTORRA Company SAS",
+    "phone": "+57XXXXXXXXXX",                // E.164. ⛔ lo aporta el dueño
+    "email": "ventas@...",                   // ⛔ dueño
+    "hasPhysicalLocation": true,             // false ⇒ omitir address/geo (service-area business)
+    "address": { "street": "", "city": "Cartagena", "region": "Bolívar", "postalCode": "", "country": "CO" }, // ⛔ dueño
+    "geo": { "lat": null, "lng": null },     // ⛔ dueño (coords del local)
+    "openingHours": []                       // ⛔ dueño. ej ["Mo-Sa 08:00-18:00"]
+  },
+  "sameAs": [],                              // ⛔ dueño: URLs REALES de redes (FB/IG/YT/TikTok/LinkedIn). cero-demo: vacío > inventado
+  "priceDisplay": "consulta",               // "real" (priceRange/priceSpecification) | "consulta" (PreOrder/InquireAction)
+
+  // ── Medición ──
+  "ga4MeasurementId": "",                    // ⛔ dueño (G-XXXX) o vacío ⇒ skill ga4 no inyecta
+  "gscVerification": "",                     // TXT/meta de Search Console (⛔ dueño)
+
+  // ── SSG ──
+  "collections": [                           // qué hornear
+    { "name": "vehiculos", "type": "item", "template": "detalle-vehiculo.html", "outDir": "vehiculos", "slugField": "slug", "statusField": "status" },
+    { "name": "marcas",    "type": "hub",   "template": "marca.html",           "outDir": "marcas" }
+  ],
+  "minBakeBytes": 5000,
+  "robotsAiBots": ["GPTBot","PerplexityBot","Google-Extended","ClaudeBot","BingBot"], // habilitar rastreo IA
+
+  // ── Feeds (product-feeds) ──
+  "feeds": [],                               // ej ["google-merchant"] (joya) | ["vehicle-ads","local-inventory"] (auto) | ["fincaraiz"] (inmob)
+
+  // ── Imágenes (image-pipeline) ──
+  "imageFormats": ["webp","avif"],
+  "imageGeoExif": false                      // EXIF geo = señal local menor/opcional
+}
+```
+
+## Campos por vertical (lo que `validateTenant` permite/prohíbe)
+| Vertical | schemaType principal | Campos VÁLIDOS (ejemplos) | PROHIBIDOS (otro vertical) |
+|---|---|---|---|
+| **JewelryStore** (Bersaglio) | `JewelryStore` + `Product` (additionalProperty: material/quilates/peso) | quilates, material, gema, talla | `kilometraje`, `VIN`, `transmision`, `habitaciones` |
+| **AutoDealer** (Altorra) | `AutoDealer` + `Car`+`Offer` (itemCondition New/Used; VIN solo PROPIOS §gate legal) | kilometraje, transmision, combustible, VIN(propios) | `quilates`, `habitaciones`, `area_m2` |
+| **RealEstateAgent** (inmobiliaria) | `RealEstateAgent` + `Residence`/`Offer` | habitaciones, baños, area_m2, estrato, parqueaderos | `kilometraje`, `VIN`, `quilates` |
+
+`validateTenant` aborta (THROW, exit 1) si un ítem trae un campo PROHIBIDO para su vertical → anti-contaminación
+cross-proyecto antes del SSG.
+
+## Datos que SOLO el dueño aporta (⛔ — la sesión-implementadora los PIDE, nunca inventa)
+`nap` (dirección/teléfono/email/horarios/coords · ¿local físico?) · `sameAs` (URLs de redes REALES) ·
+`ga4MeasurementId` / `gscVerification` / cuenta GBP (existentes o crearlas) · GCP service account para APIs ·
+decisión `priceDisplay` (real vs "bajo consulta"). **Cero-demo**: ningún campo se rellena con datos plausibles inventados.


### PR DESCRIPTION
…eo-auditor (HUB Altorra Cars, ADR §244) ⟦OPUS-4.8⟧

Consolidación cross-brain (pedido del dueño, TODO-42 en cars): el HUB (Altorra Cars) construyó el Paquete de Visibilidad y lo propaga byte-idéntico a este repo. MISMO patrón que spec-kit. Las 7 skills ya están global (~/.claude/skills) + el agente en ~/.claude/agents = usables aquí; esto agrega la copia VERSIONADA en el repo (durabilidad git, patrón de las portables).

- skills/{ssg-static-prerender(+references/ +agents/seo-auditor), semantic-schema-aeo, ga4-lead-tracking, maps-gbp-local, search-console-setup-y-diagnostico, product-feeds, image-pipeline}/ — portables vía tenant_config.json (IoC + core-funciones-puras + D′ vendored).
- Catalogadas en docs/skills-inventory.md (§Paquete de Visibilidad, nueva).
- IMPLEMENTACIÓN (tenant_config vertical=RealEstateAgent + templates + visibility-core + wiring) = sesión de ESTE proyecto, con datos REALES del dueño (cero-demo). Onboarding → ssg-static-prerender/references/.

Modelo: Opus 4.8